### PR TITLE
Add fully erased pins & Input traits for OpenDrain Output ports

### DIFF
--- a/examples/blinky_multiple.rs
+++ b/examples/blinky_multiple.rs
@@ -19,10 +19,10 @@ fn main() -> ! {
         let gpiob = p.GPIOB.split();
 
         /* (Re-)configure PA1 as output */
-        let mut led1 = gpioa.pa1.into_push_pull_output();
+        let led1 = gpioa.pa1.into_push_pull_output();
 
         /* (Re-)configure PB1 as output */
-        let mut led2 = gpiob.pb1.into_push_pull_output();
+        let led2 = gpiob.pb1.into_push_pull_output();
 
         /* Constrain clocking registers */
         let rcc = p.RCC.constrain();

--- a/examples/blinky_multiple.rs
+++ b/examples/blinky_multiple.rs
@@ -1,0 +1,52 @@
+#![no_main]
+#![no_std]
+
+use panic_halt;
+
+use stm32f0xx_hal as hal;
+
+use crate::hal::delay::Delay;
+use crate::hal::prelude::*;
+use crate::hal::stm32;
+
+use cortex_m::peripheral::Peripherals;
+use cortex_m_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    if let (Some(p), Some(cp)) = (stm32::Peripherals::take(), Peripherals::take()) {
+        let gpioa = p.GPIOA.split();
+        let gpiob = p.GPIOB.split();
+
+        /* (Re-)configure PA1 as output */
+        let mut led1 = gpioa.pa1.into_push_pull_output();
+
+        /* (Re-)configure PB1 as output */
+        let mut led2 = gpiob.pb1.into_push_pull_output();
+
+        /* Constrain clocking registers */
+        let rcc = p.RCC.constrain();
+
+        /* Configure clock to 8 MHz (i.e. the default) and freeze it */
+        let clocks = rcc.cfgr.sysclk(8.mhz()).freeze();
+
+        /* Get delay provider */
+        let mut delay = Delay::new(cp.SYST, clocks);
+
+        /* Store them together */
+        let mut leds = [led1.downgrade().downgrade(), led2.downgrade().downgrade()];
+        loop {
+            leds[0].set_high();
+            leds[1].set_high();
+            delay.delay_ms(1_000_u16);
+
+            leds[0].set_low();
+            leds[1].set_low();
+            delay.delay_ms(1_000_u16);
+        }
+    }
+
+    loop {
+        continue;
+    }
+}

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -119,6 +119,17 @@ macro_rules! gpio {
                 }
             }
 
+            impl InputPin for $PXx<Output<OpenDrain>> {
+                fn is_high(&self) -> bool {
+                    !self.is_low()
+                }
+
+                fn is_low(&self) -> bool {
+                    // NOTE(unsafe) atomic read with no side effects
+                    unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << self.i) == 0 }
+                }
+            }
+
             impl<MODE> InputPin for $PXx<Input<MODE>> {
                 fn is_high(&self) -> bool {
                     !self.is_low()
@@ -408,6 +419,17 @@ macro_rules! gpio {
                     fn set_low(&mut self) {
                         // NOTE(unsafe) atomic write to a stateless register
                         unsafe { (*$GPIOX::ptr()).bsrr.write(|w| w.bits(1 << ($i + 16))) }
+                    }
+                }
+
+                impl InputPin for $PXi<Output<OpenDrain>> {
+                    fn is_high(&self) -> bool {
+                        !self.is_low()
+                    }
+
+                    fn is_low(&self) -> bool {
+                        // NOTE(unsafe) atomic read with no side effects
+                        unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << $i) == 0 }
                     }
                 }
 

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -49,8 +49,8 @@ pub struct Output<MODE> {
 /// Push pull output (type state)
 pub struct PushPull;
 
-use hal::digital::{InputPin, OutputPin, StatefulOutputPin};
-use stm32;
+use crate::stm32;
+use embedded_hal::digital::{InputPin, OutputPin, StatefulOutputPin};
 
 /// Fully erased pin
 // We can just pretend it's gpioa. It's modified using the bits and it can only be constructed out of already existing pins
@@ -119,7 +119,7 @@ macro_rules! gpio {
             use crate::stm32::RCC;
             use super::{
                 Alternate, Floating, GpioExt, Input, OpenDrain, Output,
-                PullDown, PullUp, PushPull, AF0, AF1, AF2, AF3, AF4, AF5, AF6, AF7,
+                PullDown, PullUp, PushPull, AF0, AF1, AF2, AF3, AF4, AF5, AF6, AF7, Pin
             };
 
             /// GPIO parts
@@ -203,7 +203,7 @@ macro_rules! gpio {
                 /// This is useful when you want to collect the pins into an array where you
                 /// need all the elements to have the same type
                 pub fn downgrade(self) -> Pin<Input<MODE>> {
-                    use stm32::gpioa;
+                    use crate::stm32::gpioa;
                     use core::intrinsics::transmute;
                     Pin {
                         i: self.i,
@@ -219,7 +219,7 @@ macro_rules! gpio {
                 /// This is useful when you want to collect the pins into an array where you
                 /// need all the elements to have the same type
                 pub fn downgrade(self) -> Pin<Output<MODE>> {
-                    use stm32::gpioa;
+                    use crate::stm32::gpioa;
                     use core::intrinsics::transmute;
                     Pin {
                         i: self.i,

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -204,10 +204,9 @@ macro_rules! gpio {
                 /// need all the elements to have the same type
                 pub fn downgrade(self) -> Pin<Input<MODE>> {
                     use crate::stm32::gpioa;
-                    use core::intrinsics::transmute;
                     Pin {
                         i: self.i,
-                        port: unsafe{ transmute::<_, *const gpioa::RegisterBlock>($GPIOX::ptr())},
+                        port: $GPIOX::ptr() as * const gpioa::RegisterBlock,
                         _mode: self._mode,
                     }
                 }
@@ -220,10 +219,9 @@ macro_rules! gpio {
                 /// need all the elements to have the same type
                 pub fn downgrade(self) -> Pin<Output<MODE>> {
                     use crate::stm32::gpioa;
-                    use core::intrinsics::transmute;
                     Pin {
                         i: self.i,
-                        port: unsafe{ transmute::<_, *const gpioa::RegisterBlock>($GPIOX::ptr())},
+                        port: $GPIOX::ptr() as * const gpioa::RegisterBlock,
                         _mode: self._mode,
                     }
                 }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -49,6 +49,62 @@ pub struct Output<MODE> {
 /// Push pull output (type state)
 pub struct PushPull;
 
+use hal::digital::{InputPin, OutputPin, StatefulOutputPin};
+use stm32;
+
+/// Fully erased pin
+// We can just pretend it's gpioa. It's modified using the bits and it can only be constructed out of already existing pins
+pub struct Pin<MODE> {
+    i: u8,
+    port: *const stm32::gpioa::RegisterBlock,
+    _mode: PhantomData<MODE>,
+}
+
+impl<MODE> StatefulOutputPin for Pin<Output<MODE>> {
+    fn is_set_high(&self) -> bool {
+        !self.is_set_low()
+    }
+
+    fn is_set_low(&self) -> bool {
+        // NOTE(unsafe) atomic read with no side effects
+        unsafe { (*self.port).odr.read().bits() & (1 << self.i) == 0 }
+    }
+}
+
+impl<MODE> OutputPin for Pin<Output<MODE>> {
+    fn set_high(&mut self) {
+        // NOTE(unsafe) atomic write to a stateless register
+        unsafe { (*self.port).bsrr.write(|w| w.bits(1 << self.i)) }
+    }
+
+    fn set_low(&mut self) {
+        // NOTE(unsafe) atomic write to a stateless register
+        unsafe { (*self.port).bsrr.write(|w| w.bits(1 << (self.i + 16))) }
+    }
+}
+
+impl InputPin for Pin<Output<OpenDrain>> {
+    fn is_high(&self) -> bool {
+        !self.is_low()
+    }
+
+    fn is_low(&self) -> bool {
+        // NOTE(unsafe) atomic read with no side effects
+        unsafe { (*self.port).idr.read().bits() & (1 << self.i) == 0 }
+    }
+}
+
+impl<MODE> InputPin for Pin<Input<MODE>> {
+    fn is_high(&self) -> bool {
+        !self.is_low()
+    }
+
+    fn is_low(&self) -> bool {
+        // NOTE(unsafe) atomic read with no side effects
+        unsafe { (*self.port).idr.read().bits() & (1 << self.i) == 0 }
+    }
+}
+
 macro_rules! gpio {
     ($GPIOX:ident, $gpiox:ident, $iopxenr:ident, $PXx:ident, [
         $($PXi:ident: ($pxi:ident, $i:expr, $MODE:ty),)+
@@ -138,6 +194,38 @@ macro_rules! gpio {
                 fn is_low(&self) -> bool {
                     // NOTE(unsafe) atomic read with no side effects
                     unsafe { (*$GPIOX::ptr()).idr.read().bits() & (1 << self.i) == 0 }
+                }
+            }
+
+            impl<MODE> $PXx<Input<MODE>> {
+                /// Erases the port from the type
+                ///
+                /// This is useful when you want to collect the pins into an array where you
+                /// need all the elements to have the same type
+                pub fn downgrade(self) -> Pin<Input<MODE>> {
+                    use stm32::gpioa;
+                    use core::intrinsics::transmute;
+                    Pin {
+                        i: self.i,
+                        port: unsafe{ transmute::<_, *const gpioa::RegisterBlock>($GPIOX::ptr())},
+                        _mode: self._mode,
+                    }
+                }
+            }
+
+            impl<MODE> $PXx<Output<MODE>> {
+                /// Erases the port from the type
+                ///
+                /// This is useful when you want to collect the pins into an array where you
+                /// need all the elements to have the same type
+                pub fn downgrade(self) -> Pin<Output<MODE>> {
+                    use stm32::gpioa;
+                    use core::intrinsics::transmute;
+                    Pin {
+                        i: self.i,
+                        port: unsafe{ transmute::<_, *const gpioa::RegisterBlock>($GPIOX::ptr())},
+                        _mode: self._mode,
+                    }
                 }
             }
 


### PR DESCRIPTION
This enables pins from different Ports to be stored together. It also enables using OpenDrain pins as inputs, which is useful for multiple reasons, for example software i2c implementations. 

This code is adapted from my own stm32f030-hal crate, which also has a few other changes. It was tested there, but untested here as I don't own any 042 devices. 

Something else that caught my eye was that the 2 ```internal_pull_up``` functions have differing signatures for no discernible reason. 

I might also try a stm32f030 implementation. I'd like there to be different definitions for each different package type, as there are different pins, uarts and other peripherals available, but this seems to need a lot more code. What do you think?