### PR TITLE
[WIP] Add implementation for stm32f030

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,10 +5,10 @@ rust:
 cache: cargo
 env:
 - MCU=stm32f042
-- MCU=stm32f040
-- MCU=stm32f040x6
-- MCU=stm32f040x8
-- MCU=stm32f040xc
+- MCU=stm32f030
+- MCU=stm32f030x6
+- MCU=stm32f030x8
+- MCU=stm32f030xc
 matrix:
   allow_failures:
     - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,15 +3,16 @@ rust:
   - stable
   - nightly
 cache: cargo
+env:
+- MCU=stm32f042
+- MCU=stm32f040
+- MCU=stm32f040x6
+- MCU=stm32f040x8
+- MCU=stm32f040xc
 matrix:
   allow_failures:
     - rust: nightly
   fast_finish: true
 script:
   - rustup target add thumbv6m-none-eabi
-  - cargo build --features=stm32f042
-  - cargo build --features=stm32f030
-  - cargo build --features=stm32f030x6
-  - cargo build --features=stm32f030x8
-  - cargo build --features=stm32f030xc
-  - cargo build
+  - cargo build --features=$MCU

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,12 +3,15 @@ rust:
   - stable
   - nightly
 cache: cargo
-env:
-- MCU=stm32f042
 matrix:
   allow_failures:
     - rust: nightly
   fast_finish: true
 script:
   - rustup target add thumbv6m-none-eabi
-  - cargo build --features=$MCU
+  - cargo build --features=stm32f042
+  - cargo build --features=stm32f030
+  - cargo build --features=stm32f030x6
+  - cargo build --features=stm32f030x8
+  - cargo build --features=stm32f030xc
+  - cargo build

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,11 @@ panic-halt = "0.2.0"
 [features]
 rt = ["stm32f0/rt"]
 stm32f042 = ["stm32f0/stm32f0x2"]
+stm32f030 = ["stm32f0/stm32f0x0"]
+stm32f030x4 = ["stm32f030x6"]
+stm32f030x6 = ["stm32f030"]
+stm32f030x8 = ["stm32f0/stm32f0x0"]
+stm32f030xc = ["stm32f0/stm32f0x0"]
 
 [profile.dev]
 debug = true
@@ -52,3 +57,7 @@ debug = true
 debug = true
 lto = true
 opt-level = "s"
+
+[[example]]
+name = "led_hal_button_irq"
+required-features = ["stm32f042"]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -47,8 +47,8 @@ stm32f042 = ["stm32f0/stm32f0x2"]
 stm32f030 = ["stm32f0/stm32f0x0"]
 stm32f030x4 = ["stm32f030x6"]
 stm32f030x6 = ["stm32f030"]
-stm32f030x8 = ["stm32f0/stm32f0x0"]
-stm32f030xc = ["stm32f0/stm32f0x0"]
+stm32f030x8 = ["stm32f030", "stm32f0/stm32f0x0"]
+stm32f030xc = ["stm32f030", "stm32f0/stm32f0x0"]
 
 [profile.dev]
 debug = true

--- a/README.md
+++ b/README.md
@@ -7,6 +7,11 @@ API for the STMicro STM32F0xx family of microcontrollers. It replaces the
 
 Currently supported configuration are:
 * stm32f042
+* stm32f030
+* stm32f030x4
+* stm32f030x6
+* stm32f030x8
+* stm32f030xc
 
 The idea behind this crate is to gloss over the slight differences in the
 various peripherals available on those MCUs so a HAL can be written for all

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -450,6 +450,7 @@ macro_rules! gpio {
     }
 }
 
+#[cfg(any(feature = "stm32f042", feature = "stm32f030",))]
 gpio!(GPIOA, gpioa, iopaen, PA, [
     PA0: (pa0, 0, Input<Floating>),
     PA1: (pa1, 1, Input<Floating>),
@@ -469,6 +470,7 @@ gpio!(GPIOA, gpioa, iopaen, PA, [
     PA15: (pa15, 15, Input<Floating>),
 ]);
 
+#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
 gpio!(GPIOB, gpiob, iopben, PB, [
     PB0: (pb0, 0, Input<Floating>),
     PB1: (pb1, 1, Input<Floating>),
@@ -488,14 +490,53 @@ gpio!(GPIOB, gpiob, iopben, PB, [
     PB15: (pb15, 15, Input<Floating>),
 ]);
 
+#[cfg(feature = "stm32f042")]
 gpio!(GPIOC, gpioc, iopcen, PC, [
     PC13: (pc13, 13, Input<Floating>),
     PC14: (pc14, 14, Input<Floating>),
     PC15: (pc15, 15, Input<Floating>),
 ]);
 
+#[cfg(feature = "stm32f030")]
+gpio!(GPIOC, gpioc, iopcen, PC, [
+    PC0: (pb0, 0, Input<Floating>),
+    PC1: (pb1, 1, Input<Floating>),
+    PC2: (pb2, 2, Input<Floating>),
+    PC3: (pb3, 3, Input<Floating>),
+    PC4: (pb4, 4, Input<Floating>),
+    PC5: (pb5, 5, Input<Floating>),
+    PC6: (pb6, 6, Input<Floating>),
+    PC7: (pb7, 7, Input<Floating>),
+    PC8: (pb8, 8, Input<Floating>),
+    PC9: (pb9, 9, Input<Floating>),
+    PC10: (pb10, 10, Input<Floating>),
+    PC11: (pb11, 11, Input<Floating>),
+    PC12: (pb12, 12, Input<Floating>),
+    PC13: (pb13, 13, Input<Floating>),
+    PC14: (pb14, 14, Input<Floating>),
+    PC15: (pb15, 15, Input<Floating>),
+]);
+
+// TODO Check if the bit is implemented yet
+// In the device crate the iopden bit is missing, so it won't compile
+// #[cfg(feature = "stm32f030")]
+// gpio!(GPIOD, gpiod, iopden, PD, [
+//     PD2: (pd2, 2, Input<Floating>),
+// ]);
+
+#[cfg(feature = "stm32f042")]
 gpio!(GPIOF, gpiof, iopfen, PF, [
     PF0: (pf0, 0, Input<Floating>),
     PF1: (pf1, 1, Input<Floating>),
     PF11: (pf11, 11, Input<Floating>),
+]);
+
+#[cfg(feature = "stm32f030")]
+gpio!(GPIOF, gpiof, iopfen, PF, [
+    PF0: (pf0, 0, Input<Floating>),
+    PF1: (pf1, 1, Input<Floating>),
+    PF4: (pf4, 4, Input<Floating>),
+    PF5: (pf5, 5, Input<Floating>),
+    PF6: (pf6, 5, Input<Floating>),
+    PF7: (pf7, 5, Input<Floating>),
 ]);

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,13 +1,18 @@
+#[cfg(feature = "stm32f042")]
 use crate::stm32::{I2C1, RCC};
 
 use embedded_hal::blocking::i2c::{Write, WriteRead};
 
-use core::cmp;
+#[cfg(feature = "stm32f042")]
 use crate::gpio::gpioa::{PA10, PA11, PA12, PA9};
+#[cfg(feature = "stm32f042")]
 use crate::gpio::gpiob::{PB10, PB11, PB13, PB14, PB6, PB7, PB8, PB9};
+#[cfg(feature = "stm32f042")]
 use crate::gpio::gpiof::{PF0, PF1};
+#[cfg(feature = "stm32f042")]
 use crate::gpio::{Alternate, AF1, AF4, AF5};
 use crate::time::{KiloHertz, U32Ext};
+use core::cmp;
 
 /// I2C abstraction
 pub struct I2c<I2C, PINS> {
@@ -17,12 +22,19 @@ pub struct I2c<I2C, PINS> {
 
 pub trait Pins<I2c> {}
 
+#[cfg(feature = "stm32f042")]
 impl Pins<I2C1> for (PA9<Alternate<AF4>>, PA10<Alternate<AF4>>) {}
+#[cfg(feature = "stm32f042")]
 impl Pins<I2C1> for (PA11<Alternate<AF5>>, PA12<Alternate<AF5>>) {}
+#[cfg(feature = "stm32f042")]
 impl Pins<I2C1> for (PB6<Alternate<AF1>>, PB7<Alternate<AF1>>) {}
+#[cfg(feature = "stm32f042")]
 impl Pins<I2C1> for (PB8<Alternate<AF1>>, PB9<Alternate<AF1>>) {}
+#[cfg(feature = "stm32f042")]
 impl Pins<I2C1> for (PB10<Alternate<AF1>>, PB11<Alternate<AF1>>) {}
+#[cfg(feature = "stm32f042")]
 impl Pins<I2C1> for (PB13<Alternate<AF5>>, PB14<Alternate<AF5>>) {}
+#[cfg(feature = "stm32f042")]
 impl Pins<I2C1> for (PF1<Alternate<AF1>>, PF0<Alternate<AF1>>) {}
 
 #[derive(Debug)]
@@ -31,6 +43,7 @@ pub enum Error {
     NACK,
 }
 
+#[cfg(feature = "stm32f042")]
 impl<PINS> I2c<I2C1, PINS> {
     pub fn i2c1(i2c: I2C1, pins: PINS, speed: KiloHertz) -> Self
     where
@@ -123,6 +136,7 @@ impl<PINS> I2c<I2C1, PINS> {
     }
 }
 
+#[cfg(feature = "stm32f042")]
 impl<PINS> WriteRead for I2c<I2C1, PINS> {
     type Error = Error;
 
@@ -200,6 +214,7 @@ impl<PINS> WriteRead for I2c<I2C1, PINS> {
     }
 }
 
+#[cfg(feature = "stm32f042")]
 impl<PINS> Write for I2c<I2C1, PINS> {
     type Error = Error;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -10,6 +10,9 @@ pub use stm32f0;
 #[cfg(feature = "stm32f042")]
 pub use stm32f0::stm32f0x2 as stm32;
 
+#[cfg(feature = "stm32f030")]
+pub use stm32f0::stm32f0x0 as stm32;
+
 // Enable use of interrupt macro
 #[cfg(feature = "rt")]
 pub use stm32f0::interrupt;

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -1,6 +1,6 @@
 use core::cmp;
 
-#[cfg(feature = "stm32f042")]
+#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
 use crate::stm32::{FLASH, RCC};
 use cast::u32;
 
@@ -12,7 +12,7 @@ pub trait RccExt {
     fn constrain(self) -> Rcc;
 }
 
-#[cfg(feature = "stm32f042")]
+#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
 impl RccExt for RCC {
     fn constrain(self) -> Rcc {
         Rcc {
@@ -38,7 +38,7 @@ pub struct CFGR {
     sysclk: Option<u32>,
 }
 
-#[cfg(feature = "stm32f042")]
+#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
 impl CFGR {
     pub fn hclk<F>(mut self, freq: F) -> Self
     where

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -1,7 +1,8 @@
 use core::cmp;
 
-use cast::u32;
+#[cfg(feature = "stm32f042")]
 use crate::stm32::{FLASH, RCC};
+use cast::u32;
 
 use crate::time::Hertz;
 
@@ -11,6 +12,7 @@ pub trait RccExt {
     fn constrain(self) -> Rcc;
 }
 
+#[cfg(feature = "stm32f042")]
 impl RccExt for RCC {
     fn constrain(self) -> Rcc {
         Rcc {
@@ -36,6 +38,7 @@ pub struct CFGR {
     sysclk: Option<u32>,
 }
 
+#[cfg(feature = "stm32f042")]
 impl CFGR {
     pub fn hclk<F>(mut self, freq: F) -> Self
     where

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -39,14 +39,41 @@ pub enum Error {
 
 pub trait Pins<USART> {}
 
+#[cfg(any(feature = "stm32f030", feature = "stm32f042"))]
 impl Pins<USART1> for (PA9<Alternate<AF1>>, PA10<Alternate<AF1>>) {}
+#[cfg(any(feature = "stm32f030", feature = "stm32f042"))]
 impl Pins<USART1> for (PB6<Alternate<AF0>>, PB7<Alternate<AF0>>) {}
+#[cfg(any(feature = "stm32f030", feature = "stm32f042"))]
 impl Pins<USART1> for (PA9<Alternate<AF1>>, PB7<Alternate<AF0>>) {}
+#[cfg(any(feature = "stm32f030", feature = "stm32f042"))]
 impl Pins<USART1> for (PB6<Alternate<AF0>>, PA10<Alternate<AF1>>) {}
 
+#[cfg(feature = "stm32f030x6")]
+impl Pins<USART1> for (PA2<Alternate<AF1>>, PA3<Alternate<AF1>>) {}
+
+#[cfg(any(
+    feature = "stm32f042",
+    feature = "stm32f030x8",
+    feature = "stm32f030xc",
+))]
 impl Pins<USART2> for (PA2<Alternate<AF1>>, PA3<Alternate<AF1>>) {}
+#[cfg(any(
+    feature = "stm32f042",
+    feature = "stm32f030x8",
+    feature = "stm32f030xc",
+))]
 impl Pins<USART2> for (PA2<Alternate<AF1>>, PA15<Alternate<AF1>>) {}
+#[cfg(any(
+    feature = "stm32f042",
+    feature = "stm32f030x8",
+    feature = "stm32f030xc",
+))]
 impl Pins<USART2> for (PA14<Alternate<AF1>>, PA15<Alternate<AF1>>) {}
+#[cfg(any(
+    feature = "stm32f042",
+    feature = "stm32f030x8",
+    feature = "stm32f030xc",
+))]
 impl Pins<USART2> for (PA14<Alternate<AF1>>, PA3<Alternate<AF1>>) {}
 
 /// Serial abstraction

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -6,11 +6,10 @@ use embedded_hal::prelude::*;
 use nb::block;
 use void::Void;
 
+#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
 use crate::stm32::{RCC, USART1, USART2};
 
-use crate::gpio::gpioa::{PA10, PA14, PA15, PA2, PA3, PA9};
-use crate::gpio::gpiob::{PB6, PB7};
-use crate::gpio::{Alternate, AF0, AF1};
+use crate::gpio::*;
 use crate::rcc::Clocks;
 use crate::time::Bps;
 
@@ -40,41 +39,41 @@ pub enum Error {
 pub trait Pins<USART> {}
 
 #[cfg(any(feature = "stm32f030", feature = "stm32f042"))]
-impl Pins<USART1> for (PA9<Alternate<AF1>>, PA10<Alternate<AF1>>) {}
+impl Pins<USART1> for (gpioa::PA9<Alternate<AF1>>, gpioa::PA10<Alternate<AF1>>) {}
 #[cfg(any(feature = "stm32f030", feature = "stm32f042"))]
-impl Pins<USART1> for (PB6<Alternate<AF0>>, PB7<Alternate<AF0>>) {}
+impl Pins<USART1> for (gpiob::PB6<Alternate<AF0>>, gpiob::PB7<Alternate<AF0>>) {}
 #[cfg(any(feature = "stm32f030", feature = "stm32f042"))]
-impl Pins<USART1> for (PA9<Alternate<AF1>>, PB7<Alternate<AF0>>) {}
+impl Pins<USART1> for (gpioa::PA9<Alternate<AF1>>, gpiob::PB7<Alternate<AF0>>) {}
 #[cfg(any(feature = "stm32f030", feature = "stm32f042"))]
-impl Pins<USART1> for (PB6<Alternate<AF0>>, PA10<Alternate<AF1>>) {}
+impl Pins<USART1> for (gpiob::PB6<Alternate<AF0>>, gpioa::PA10<Alternate<AF1>>) {}
 
 #[cfg(feature = "stm32f030x6")]
-impl Pins<USART1> for (PA2<Alternate<AF1>>, PA3<Alternate<AF1>>) {}
+impl Pins<USART1> for (gpioa::PA2<Alternate<AF1>>, gpioa::PA3<Alternate<AF1>>) {}
 
 #[cfg(any(
     feature = "stm32f042",
     feature = "stm32f030x8",
     feature = "stm32f030xc",
 ))]
-impl Pins<USART2> for (PA2<Alternate<AF1>>, PA3<Alternate<AF1>>) {}
+impl Pins<USART2> for (gpioa::PA2<Alternate<AF1>>, gpioa::PA3<Alternate<AF1>>) {}
 #[cfg(any(
     feature = "stm32f042",
     feature = "stm32f030x8",
     feature = "stm32f030xc",
 ))]
-impl Pins<USART2> for (PA2<Alternate<AF1>>, PA15<Alternate<AF1>>) {}
+impl Pins<USART2> for (gpioa::PA2<Alternate<AF1>>, gpioa::PA15<Alternate<AF1>>) {}
 #[cfg(any(
     feature = "stm32f042",
     feature = "stm32f030x8",
     feature = "stm32f030xc",
 ))]
-impl Pins<USART2> for (PA14<Alternate<AF1>>, PA15<Alternate<AF1>>) {}
+impl Pins<USART2> for (gpioa::PA14<Alternate<AF1>>, gpioa::PA15<Alternate<AF1>>) {}
 #[cfg(any(
     feature = "stm32f042",
     feature = "stm32f030x8",
     feature = "stm32f030xc",
 ))]
-impl Pins<USART2> for (PA14<Alternate<AF1>>, PA3<Alternate<AF1>>) {}
+impl Pins<USART2> for (gpioa::PA14<Alternate<AF1>>, gpioa::PA3<Alternate<AF1>>) {}
 
 /// Serial abstraction
 pub struct Serial<USART, PINS> {
@@ -93,6 +92,7 @@ pub struct Tx<USART> {
 }
 
 /// USART1
+#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
 impl<PINS> Serial<USART1, PINS> {
     pub fn usart1(usart: USART1, pins: PINS, baud_rate: Bps, clocks: Clocks) -> Self
     where
@@ -133,6 +133,7 @@ impl<PINS> Serial<USART1, PINS> {
     }
 }
 
+#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
 impl embedded_hal::serial::Read<u8> for Rx<USART1> {
     type Error = Error;
 
@@ -157,6 +158,7 @@ impl embedded_hal::serial::Read<u8> for Rx<USART1> {
     }
 }
 
+#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
 impl embedded_hal::serial::Write<u8> for Tx<USART1> {
     type Error = Void;
 
@@ -187,6 +189,11 @@ impl embedded_hal::serial::Write<u8> for Tx<USART1> {
 }
 
 /// USART2
+#[cfg(any(
+    feature = "stm32f042",
+    feature = "stm32f030x8",
+    feature = "stm32f030x8"
+))]
 impl<PINS> Serial<USART2, PINS> {
     pub fn usart2(usart: USART2, pins: PINS, baud_rate: Bps, clocks: Clocks) -> Self
     where
@@ -227,6 +234,11 @@ impl<PINS> Serial<USART2, PINS> {
     }
 }
 
+#[cfg(any(
+    feature = "stm32f042",
+    feature = "stm32f030x8",
+    feature = "stm32f030x8"
+))]
 impl embedded_hal::serial::Read<u8> for Rx<USART2> {
     type Error = Error;
 
@@ -251,6 +263,11 @@ impl embedded_hal::serial::Read<u8> for Rx<USART2> {
     }
 }
 
+#[cfg(any(
+    feature = "stm32f042",
+    feature = "stm32f030x8",
+    feature = "stm32f030x8"
+))]
 impl embedded_hal::serial::Write<u8> for Tx<USART2> {
     type Error = Void;
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -4,11 +4,10 @@ use nb;
 
 pub use embedded_hal::spi::{Mode, Phase, Polarity};
 
+#[cfg(feature = "stm32f042")]
 use crate::stm32::{RCC, SPI1};
 
-use crate::gpio::gpioa::{PA5, PA6, PA7};
-use crate::gpio::gpiob::{PB3, PB4, PB5};
-use crate::gpio::{Alternate, AF0};
+use crate::gpio::*;
 use crate::rcc::Clocks;
 use crate::time::Hertz;
 
@@ -33,21 +32,26 @@ pub struct Spi<SPI, PINS> {
 
 pub trait Pins<Spi> {}
 
+#[cfg(feature = "stm32f042")]
 impl Pins<SPI1>
     for (
-        PA5<Alternate<AF0>>,
-        PA6<Alternate<AF0>>,
-        PA7<Alternate<AF0>>,
+        gpioa::PA5<Alternate<AF0>>,
+        gpioa::PA6<Alternate<AF0>>,
+        gpioa::PA7<Alternate<AF0>>,
     )
-{}
+{
+}
+#[cfg(feature = "stm32f042")]
 impl Pins<SPI1>
     for (
-        PB3<Alternate<AF0>>,
-        PB4<Alternate<AF0>>,
-        PB5<Alternate<AF0>>,
+        gpiob::PB3<Alternate<AF0>>,
+        gpiob::PB4<Alternate<AF0>>,
+        gpiob::PB5<Alternate<AF0>>,
     )
-{}
+{
+}
 
+#[cfg(feature = "stm32f042")]
 impl<PINS> Spi<SPI1, PINS> {
     pub fn spi1<F>(spi: SPI1, pins: PINS, mode: Mode, speed: F, clocks: Clocks) -> Self
     where
@@ -126,6 +130,7 @@ impl<PINS> Spi<SPI1, PINS> {
     }
 }
 
+#[cfg(feature = "stm32f042")]
 impl<PINS> ::embedded_hal::spi::FullDuplex<u8> for Spi<SPI1, PINS> {
     type Error = Error;
 
@@ -166,5 +171,7 @@ impl<PINS> ::embedded_hal::spi::FullDuplex<u8> for Spi<SPI1, PINS> {
     }
 }
 
+#[cfg(feature = "stm32f042")]
 impl<PINS> ::embedded_hal::blocking::spi::transfer::Default<u8> for Spi<SPI1, PINS> {}
+#[cfg(feature = "stm32f042")]
 impl<PINS> ::embedded_hal::blocking::spi::write::Default<u8> for Spi<SPI1, PINS> {}


### PR DESCRIPTION
Currently adds
- GPIO
- UART (partial)
- RCC

Currently it's hard to conditionally add some peripherals. I'd wrap then in a macro, especially for the uarts, since stm32f030xc has 6 of them.

The question is also how to do the multiple pin combinations for AF configurations. Individually adding them is a bit inconvenient. Is there any concrete reasoning behind having pin combinations and not just individual pins with usartRX/usartTX/i2cSDA/i2cSCL traits?