### PR TITLE
Fully erased pins based on trait implementations

### DIFF
--- a/examples/blinky_multiple.rs
+++ b/examples/blinky_multiple.rs
@@ -34,14 +34,16 @@ fn main() -> ! {
         let mut delay = Delay::new(cp.SYST, clocks);
 
         /* Store them together */
-        let mut leds = [led1.downgrade().downgrade(), led2.downgrade().downgrade()];
+        let mut leds = [led1.downgrade(), led2.downgrade()];
         loop {
-            leds[0].set_high();
-            leds[1].set_high();
+            for l in &mut leds {
+                l.set_high();
+            }
             delay.delay_ms(1_000_u16);
 
-            leds[0].set_low();
-            leds[1].set_low();
+            for l in &mut leds {
+                l.set_low();
+            }
             delay.delay_ms(1_000_u16);
         }
     }

--- a/examples/blinky_multiple.rs
+++ b/examples/blinky_multiple.rs
@@ -1,0 +1,52 @@
+#![no_main]
+#![no_std]
+
+use panic_halt;
+
+use stm32f0xx_hal as hal;
+
+use crate::hal::delay::Delay;
+use crate::hal::prelude::*;
+use crate::hal::stm32;
+
+use cortex_m::peripheral::Peripherals;
+use cortex_m_rt::entry;
+
+#[entry]
+fn main() -> ! {
+    if let (Some(p), Some(cp)) = (stm32::Peripherals::take(), Peripherals::take()) {
+        let gpioa = p.GPIOA.split();
+        let gpiob = p.GPIOB.split();
+
+        /* (Re-)configure PA1 as output */
+        let led1 = gpioa.pa1.into_push_pull_output();
+
+        /* (Re-)configure PB1 as output */
+        let led2 = gpiob.pb1.into_push_pull_output();
+
+        /* Constrain clocking registers */
+        let rcc = p.RCC.constrain();
+
+        /* Configure clock to 8 MHz (i.e. the default) and freeze it */
+        let clocks = rcc.cfgr.sysclk(8.mhz()).freeze();
+
+        /* Get delay provider */
+        let mut delay = Delay::new(cp.SYST, clocks);
+
+        /* Store them together */
+        let mut leds = [led1.downgrade().downgrade(), led2.downgrade().downgrade()];
+        loop {
+            leds[0].set_high();
+            leds[1].set_high();
+            delay.delay_ms(1_000_u16);
+
+            leds[0].set_low();
+            leds[1].set_low();
+            delay.delay_ms(1_000_u16);
+        }
+    }
+
+    loop {
+        continue;
+    }
+}

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -56,8 +56,7 @@ pub struct Output<MODE> {
 /// Push pull output (type state)
 pub struct PushPull;
 
-use crate::stm32;
-use embedded_hal::digital::{InputPin, OutputPin, StatefulOutputPin};
+use embedded_hal::digital::{InputPin, OutputPin, StatefulOutputPin, toggleable};
 
 /// Fully erased pin
 pub struct Pin<MODE> {
@@ -85,6 +84,8 @@ impl<MODE> OutputPin for Pin<Output<MODE>> {
         unsafe { (*self.port).set_low(self.i) }
     }
 }
+
+impl<MODE> toggleable::Default for Pin<Output<MODE>> {}
 
 impl InputPin for Pin<Output<OpenDrain>> {
     fn is_high(&self) -> bool {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -15,7 +15,7 @@ trait GpioRegExt {
     fn in_low(&self, pos: u8) -> bool;
     fn out_low(&self, pos: u8) -> bool;
     fn set_high(&self, pos: u8);
-    fn set_low(&self, pos:u8);
+    fn set_low(&self, pos: u8);
 }
 
 pub struct AF0;
@@ -56,7 +56,7 @@ pub struct Output<MODE> {
 /// Push pull output (type state)
 pub struct PushPull;
 
-use embedded_hal::digital::{InputPin, OutputPin, StatefulOutputPin, toggleable};
+use embedded_hal::digital::{toggleable, InputPin, OutputPin, StatefulOutputPin};
 
 /// Fully erased pin
 pub struct Pin<MODE> {
@@ -109,28 +109,28 @@ impl<MODE> InputPin for Pin<Input<MODE>> {
 
 macro_rules! gpio_trait {
     ($gpiox:ident) => {
-          impl GpioRegExt for crate::stm32::$gpiox::RegisterBlock {
-                fn in_low(&self, pos :u8) -> bool {
-                    // NOTE(unsafe) atomic read with no side effects
-                    self.idr.read().bits() & (1 << pos) == 0
-                }
+        impl GpioRegExt for crate::stm32::$gpiox::RegisterBlock {
+            fn in_low(&self, pos: u8) -> bool {
+                // NOTE(unsafe) atomic read with no side effects
+                self.idr.read().bits() & (1 << pos) == 0
+            }
 
-                fn out_low(&self, pos: u8) -> bool {
-                    // NOTE(unsafe) atomic read with no side effects
-                    self.odr.read().bits() & (1 << pos) == 0
-                }
+            fn out_low(&self, pos: u8) -> bool {
+                // NOTE(unsafe) atomic read with no side effects
+                self.odr.read().bits() & (1 << pos) == 0
+            }
 
-                fn set_high(&self, pos: u8) {
-                    // NOTE(unsafe) atomic write to a stateless register
-                    unsafe { self.bsrr.write(|w| w.bits(1 << pos)) }
-                }
+            fn set_high(&self, pos: u8) {
+                // NOTE(unsafe) atomic write to a stateless register
+                unsafe { self.bsrr.write(|w| w.bits(1 << pos)) }
+            }
 
-                fn set_low(&self, pos: u8) {
-                    // NOTE(unsafe) atomic write to a stateless register
-                    unsafe { self.bsrr.write(|w| w.bits(1 << (pos + 16))) }
-                }
-          }
-    }
+            fn set_low(&self, pos: u8) {
+                // NOTE(unsafe) atomic write to a stateless register
+                unsafe { self.bsrr.write(|w| w.bits(1 << (pos + 16))) }
+            }
+        }
+    };
 }
 
 gpio_trait!(gpioa);

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -11,7 +11,7 @@ pub trait GpioExt {
     fn split(self) -> Self::Parts;
 }
 
-pub trait Gpio {
+trait GpioRegExt {
     fn in_low(&self, pos: u8) -> bool;
     fn out_low(&self, pos: u8) -> bool;
     fn set_high(&self, pos: u8);
@@ -61,7 +61,7 @@ use embedded_hal::digital::{InputPin, OutputPin, StatefulOutputPin, toggleable};
 /// Fully erased pin
 pub struct Pin<MODE> {
     i: u8,
-    port: *const Gpio,
+    port: *const GpioRegExt,
     _mode: PhantomData<MODE>,
 }
 
@@ -109,7 +109,7 @@ impl<MODE> InputPin for Pin<Input<MODE>> {
 
 macro_rules! gpio_trait {
     ($gpiox:ident) => {
-          impl Gpio for crate::stm32::$gpiox::RegisterBlock {
+          impl GpioRegExt for crate::stm32::$gpiox::RegisterBlock {
                 fn in_low(&self, pos :u8) -> bool {
                     // NOTE(unsafe) atomic read with no side effects
                     self.idr.read().bits() & (1 << pos) == 0
@@ -151,7 +151,7 @@ macro_rules! gpio {
             use super::{
                 Alternate, Floating, GpioExt, Input, OpenDrain, Output,
                 PullDown, PullUp, PushPull, AF0, AF1, AF2, AF3, AF4, AF5, AF6, AF7,
-                Pin, Gpio,
+                Pin, GpioRegExt,
             };
 
             /// GPIO parts
@@ -431,7 +431,7 @@ macro_rules! gpio {
                     pub fn downgrade(self) -> Pin<Output<MODE>> {
                         Pin {
                             i: $i,
-                            port: $GPIOX::ptr() as *const Gpio,
+                            port: $GPIOX::ptr() as *const GpioRegExt,
                             _mode: self._mode,
                         }
                     }
@@ -477,7 +477,7 @@ macro_rules! gpio {
                     pub fn downgrade(self) -> Pin<Input<MODE>> {
                         Pin {
                             i: $i,
-                            port: $GPIOX::ptr() as *const Gpio,
+                            port: $GPIOX::ptr() as *const GpioRegExt,
                             _mode: self._mode,
                         }
                     }

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -12,8 +12,8 @@ pub trait GpioExt {
 }
 
 trait GpioRegExt {
-    fn in_low(&self, pos: u8) -> bool;
-    fn out_low(&self, pos: u8) -> bool;
+    fn is_low(&self, pos: u8) -> bool;
+    fn is_set_low(&self, pos: u8) -> bool;
     fn set_high(&self, pos: u8);
     fn set_low(&self, pos: u8);
 }
@@ -71,7 +71,7 @@ impl<MODE> StatefulOutputPin for Pin<Output<MODE>> {
     }
 
     fn is_set_low(&self) -> bool {
-        unsafe { (*self.port).out_low(self.i) }
+        unsafe { (*self.port).is_set_low(self.i) }
     }
 }
 
@@ -93,7 +93,7 @@ impl InputPin for Pin<Output<OpenDrain>> {
     }
 
     fn is_low(&self) -> bool {
-        unsafe { (*self.port).in_low(self.i) }
+        unsafe { (*self.port).is_low(self.i) }
     }
 }
 
@@ -103,19 +103,19 @@ impl<MODE> InputPin for Pin<Input<MODE>> {
     }
 
     fn is_low(&self) -> bool {
-        unsafe { (*self.port).in_low(self.i) }
+        unsafe { (*self.port).is_low(self.i) }
     }
 }
 
 macro_rules! gpio_trait {
     ($gpiox:ident) => {
         impl GpioRegExt for crate::stm32::$gpiox::RegisterBlock {
-            fn in_low(&self, pos: u8) -> bool {
+            fn is_low(&self, pos: u8) -> bool {
                 // NOTE(unsafe) atomic read with no side effects
                 self.idr.read().bits() & (1 << pos) == 0
             }
 
-            fn out_low(&self, pos: u8) -> bool {
+            fn is_set_low(&self, pos: u8) -> bool {
                 // NOTE(unsafe) atomic read with no side effects
                 self.odr.read().bits() & (1 << pos) == 0
             }
@@ -443,7 +443,7 @@ macro_rules! gpio {
                     }
 
                     fn is_set_low(&self) -> bool {
-                        unsafe { (*$GPIOX::ptr()).out_low($i) }
+                        unsafe { (*$GPIOX::ptr()).is_set_low($i) }
                     }
                 }
 
@@ -465,7 +465,7 @@ macro_rules! gpio {
                     }
 
                     fn is_low(&self) -> bool {
-                        unsafe { (*$GPIOX::ptr()).in_low($i) }
+                        unsafe { (*$GPIOX::ptr()).is_low($i) }
                     }
                 }
 
@@ -489,7 +489,7 @@ macro_rules! gpio {
                     }
 
                     fn is_low(&self) -> bool {
-                        unsafe { (*$GPIOX::ptr()).in_low($i) }
+                        unsafe { (*$GPIOX::ptr()).is_low($i) }
                     }
                 }
             )+

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -443,17 +443,17 @@ macro_rules! gpio {
                     }
 
                     fn is_set_low(&self) -> bool {
-                        (*$GPIOX::ptr()).out_low($i)
+                        unsafe { (*$GPIOX::ptr()).out_low($i) }
                     }
                 }
 
                 impl<MODE> OutputPin for $PXi<Output<MODE>> {
                     fn set_high(&mut self) {
-                        (*$GPIOX::ptr()).set_high($i)
+                        unsafe { (*$GPIOX::ptr()).set_high($i) }
                     }
 
                     fn set_low(&mut self) {
-                        (*$GPIOX::ptr()).set_low($i)
+                        unsafe { (*$GPIOX::ptr()).set_low($i) }
                     }
                 }
 
@@ -465,7 +465,7 @@ macro_rules! gpio {
                     }
 
                     fn is_low(&self) -> bool {
-                        (*$GPIOX::ptr()).in_low($i)
+                        unsafe { (*$GPIOX::ptr()).in_low($i) }
                     }
                 }
 
@@ -489,7 +489,7 @@ macro_rules! gpio {
                     }
 
                     fn is_low(&self) -> bool {
-                        (*$GPIOX::ptr()).in_low($i)
+                        unsafe { (*$GPIOX::ptr()).in_low($i) }
                     }
                 }
             )+


### PR DESCRIPTION
Result of discussion on #2. Adds an implementation of fully erased pins that works based on trait implementation. Currently uses a macro definition to assign the trait, this may be fixed later by some work done to svd2rust to make gpio register block definition more standard.
Based on and features code by @david-sawatzke from his PR #2.