### PR TITLE
Add more peripherals for the stm32f030

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,8 +51,8 @@ stm32f042 = ["stm32f0/stm32f0x2"]
 stm32f030 = ["stm32f0/stm32f0x0"]
 stm32f030x4 = ["stm32f030x6"]
 stm32f030x6 = ["stm32f030"]
-stm32f030x8 = ["stm32f030", "stm32f0/stm32f0x0"]
-stm32f030xc = ["stm32f030", "stm32f0/stm32f0x0"]
+stm32f030x8 = ["stm32f030"]
+stm32f030xc = ["stm32f030"]
 
 [profile.dev]
 debug = true

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -564,12 +564,10 @@ gpio!(GPIOC, gpioc, iopcen, PC, [
     PC15: (pb15, 15, Input<Floating>),
 ]);
 
-// TODO Check if the bit is implemented yet
-// In the device crate the iopden bit is missing, so it won't compile
-// #[cfg(feature = "stm32f030")]
-// gpio!(GPIOD, gpiod, iopden, PD, [
-//     PD2: (pd2, 2, Input<Floating>),
-// ]);
+#[cfg(feature = "stm32f030")]
+gpio!(GPIOD, gpiod, iopden, PD, [
+    PD2: (pd2, 2, Input<Floating>),
+]);
 
 #[cfg(feature = "stm32f042")]
 gpio!(GPIOF, gpiof, iopfen, PF, [

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,18 +1,11 @@
-#[cfg(feature = "stm32f042")]
+#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
 use crate::stm32::{I2C1, RCC};
 
 use embedded_hal::blocking::i2c::{Write, WriteRead};
 
-use core::cmp;
-#[cfg(feature = "stm32f042")]
-use crate::gpio::gpioa::{PA10, PA11, PA12, PA9};
-#[cfg(feature = "stm32f042")]
-use crate::gpio::gpiob::{PB10, PB11, PB13, PB14, PB6, PB7, PB8, PB9};
-#[cfg(feature = "stm32f042")]
-use crate::gpio::gpiof::{PF0, PF1};
-#[cfg(feature = "stm32f042")]
-use crate::gpio::{Alternate, AF1, AF4, AF5};
+use crate::gpio::*;
 use crate::time::{KiloHertz, U32Ext};
+use core::cmp;
 
 /// I2C abstraction
 pub struct I2c<I2C, PINS> {
@@ -22,20 +15,24 @@ pub struct I2c<I2C, PINS> {
 
 pub trait Pins<I2c> {}
 
-#[cfg(feature = "stm32f042")]
-impl Pins<I2C1> for (PA9<Alternate<AF4>>, PA10<Alternate<AF4>>) {}
-#[cfg(feature = "stm32f042")]
-impl Pins<I2C1> for (PA11<Alternate<AF5>>, PA12<Alternate<AF5>>) {}
-#[cfg(feature = "stm32f042")]
-impl Pins<I2C1> for (PB6<Alternate<AF1>>, PB7<Alternate<AF1>>) {}
-#[cfg(feature = "stm32f042")]
-impl Pins<I2C1> for (PB8<Alternate<AF1>>, PB9<Alternate<AF1>>) {}
-#[cfg(feature = "stm32f042")]
-impl Pins<I2C1> for (PB10<Alternate<AF1>>, PB11<Alternate<AF1>>) {}
-#[cfg(feature = "stm32f042")]
-impl Pins<I2C1> for (PB13<Alternate<AF5>>, PB14<Alternate<AF5>>) {}
-#[cfg(feature = "stm32f042")]
-impl Pins<I2C1> for (PF1<Alternate<AF1>>, PF0<Alternate<AF1>>) {}
+#[cfg(any(
+    feature = "stm32f042",
+    feature = "stm32f030x6",
+    feature = "stm32f030xc"
+))]
+impl Pins<I2C1> for (gpioa::PA9<Alternate<AF4>>, gpioa::PA10<Alternate<AF4>>) {}
+#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
+impl Pins<I2C1> for (gpioa::PA11<Alternate<AF5>>, gpioa::PA12<Alternate<AF5>>) {}
+#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
+impl Pins<I2C1> for (gpiob::PB6<Alternate<AF1>>, gpiob::PB7<Alternate<AF1>>) {}
+#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
+impl Pins<I2C1> for (gpiob::PB8<Alternate<AF1>>, gpiob::PB9<Alternate<AF1>>) {}
+#[cfg(any(feature = "stm32f042", feature = "stm32f030x6"))]
+impl Pins<I2C1> for (gpiob::PB10<Alternate<AF1>>, gpiob::PB11<Alternate<AF1>>) {}
+#[cfg(any(feature = "stm32f042", feature = "stm32f030xc"))]
+impl Pins<I2C1> for (gpiob::PB13<Alternate<AF5>>, gpiob::PB14<Alternate<AF5>>) {}
+#[cfg(any(feature = "stm32f042", feature = "stm32f030xc"))]
+impl Pins<I2C1> for (gpiof::PF1<Alternate<AF1>>, gpiof::PF0<Alternate<AF1>>) {}
 
 #[derive(Debug)]
 pub enum Error {
@@ -43,7 +40,7 @@ pub enum Error {
     NACK,
 }
 
-#[cfg(feature = "stm32f042")]
+#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
 impl<PINS> I2c<I2C1, PINS> {
     pub fn i2c1(i2c: I2C1, pins: PINS, speed: KiloHertz) -> Self
     where
@@ -136,7 +133,7 @@ impl<PINS> I2c<I2C1, PINS> {
     }
 }
 
-#[cfg(feature = "stm32f042")]
+#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
 impl<PINS> WriteRead for I2c<I2C1, PINS> {
     type Error = Error;
 
@@ -214,7 +211,7 @@ impl<PINS> WriteRead for I2c<I2C1, PINS> {
     }
 }
 
-#[cfg(feature = "stm32f042")]
+#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
 impl<PINS> Write for I2c<I2C1, PINS> {
     type Error = Error;
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -269,8 +269,6 @@ where
 impl<USART, TXPIN, RXPIN> Serial<USART, TXPIN, RXPIN>
 where
     USART: Deref<Target = SerialRegisterBlock>,
-    TXPIN: TxPin<USART>,
-    RXPIN: RxPin<USART>,
 {
     /// Splits the UART Peripheral in a Tx and an Rx part
     /// This is required for sending/receiving

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -107,11 +107,10 @@ usart_pins! {
 }
 #[cfg(feature = "stm32f030xc")]
 usart_pins! {
-    // TODO WTF look at this again, in the datasheet PB10 is both tx and rx
-    // USART3: (gpiob::PB10, AF4, gpiob::PA11, AF4),
     USART3 => {
-        tx => [gpioc::PC4<Alternate<AF1>>, gpioc::PC10<Alternate<AF1>>],
-        rx => [gpioc::PC5<Alternate<AF1>>, gpioc::PC11<Alternate<AF1>>],
+        // TODO WTF look at this again, in the datasheet PB10 is both tx and rx
+        tx => [/*gpiob::PB10<Alternate<AF4>>,*/ gpioc::PC4<Alternate<AF1>>, gpioc::PC10<Alternate<AF1>>],
+        rx => [gpiob::PB11<Alternate<AF4>>, gpioc::PC5<Alternate<AF1>>, gpioc::PC11<Alternate<AF1>>],
     }
     USART4 => {
         tx => [gpioa::PA0<Alternate<AF4>>, gpioc::PC10<Alternate<AF0>>],

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -65,23 +65,34 @@ pub trait TxPin<USART> {}
 pub trait RxPin<USART> {}
 
 macro_rules! usart_pins {
-    ($($USART:ident: ($tx:ty, $rx:ty),)+) => {
+    ($($USART:ident => {
+        tx => [$($tx:ty),+ $(,)*],
+        rx => [$($rx:ty),+ $(,)*],
+    })+) => {
         $(
-            impl TxPin<stm32::$USART> for $tx {}
-            impl RxPin<stm32::$USART> for $rx {}
+            $(
+                impl TxPin<stm32::$USART> for $tx {}
+            )+
+            $(
+                impl RxPin<stm32::$USART> for $rx {}
+            )+
         )+
     }
 }
 
 #[cfg(any(feature = "stm32f030", feature = "stm32f042"))]
 usart_pins! {
-    USART1: (gpioa::PA9<Alternate<AF1>>, gpioa::PA10<Alternate<AF1>>),
-    USART1: (gpiob::PB6<Alternate<AF0>>, gpiob::PB6<Alternate<AF0>>),
+    USART1 =>  {
+        tx => [gpioa::PA9<Alternate<AF1>>, gpiob::PB6<Alternate<AF0>>],
+        rx => [gpioa::PA10<Alternate<AF1>>, gpiob::PB6<Alternate<AF0>>],
+    }
 }
 #[cfg(feature = "stm32f030x6")]
 usart_pins! {
-    USART1: (gpioa::PA2<Alternate<AF1>>, gpioa::PA3<Alternate<AF1>>),
-    USART1: (gpioa::PA14<Alternate<AF1>>, gpioa::PA15<Alternate<AF1>>),
+    USART1 => {
+        tx => [gpioa::PA2<Alternate<AF1>>, gpioa::PA14<Alternate<AF1>>],
+        rx => [gpioa::PA3<Alternate<AF1>>, gpioa::PA15<Alternate<AF1>>],
+    }
 }
 #[cfg(any(
     feature = "stm32f042",
@@ -89,21 +100,31 @@ usart_pins! {
     feature = "stm32f030xc",
 ))]
 usart_pins! {
-    USART2: (gpioa::PA2<Alternate<AF1>>, gpioa::PA3<Alternate<AF1>>),
-    USART2: (gpioa::PA14<Alternate<AF1>>, gpioa::PA15<Alternate<AF1>>),
+    USART2 => {
+        tx => [gpioa::PA2<Alternate<AF1>>, gpioa::PA14<Alternate<AF1>>],
+        rx => [gpioa::PA3<Alternate<AF1>>, gpioa::PA15<Alternate<AF1>>],
+    }
 }
 #[cfg(feature = "stm32f030xc")]
 usart_pins! {
     // TODO WTF look at this again, in the datasheet PB10 is both tx and rx
     // USART3: (gpiob::PB10, AF4, gpiob::PA11, AF4),
-    USART3: (gpioc::PC4<Alternate<AF1>>, gpioc::PC5<Alternate<AF1>>),
-    USART3: (gpioc::PC10<Alternate<AF1>>, gpioc::PC11<Alternate<AF1>>),
-    USART4: (gpioa::PA0<Alternate<AF4>>, gpioa::PA1<Alternate<AF4>>),
-    USART4: (gpioc::PC10<Alternate<AF0>>, gpioc::PC11<Alternate<AF0>>),
-    USART5: (gpiob::PB3<Alternate<AF4>>, gpiob::PB4<Alternate<AF4>>),
-    USART5: (gpioc::PC12<Alternate<AF2>>, gpiod::PD2<Alternate<AF2>>),
-    USART6: (gpioa::PA4<Alternate<AF5>>, gpioa::PA5<Alternate<AF5>>),
-    USART6: (gpioc::PC0<Alternate<AF2>>, gpioc::PC1<Alternate<AF2>>),
+    USART3 => {
+        tx => [gpioc::PC4<Alternate<AF1>>, gpioc::PC10<Alternate<AF1>>],
+        rx => [gpioc::PC5<Alternate<AF1>>, gpioc::PC11<Alternate<AF1>>],
+    }
+    USART4 => {
+        tx => [gpioa::PA0<Alternate<AF4>>, gpioc::PC10<Alternate<AF0>>],
+        rx => [gpioa::PA1<Alternate<AF4>>, gpioc::PC11<Alternate<AF0>>],
+    }
+    USART5 => {
+        tx => [gpiob::PB3<Alternate<AF4>>, gpioc::PC12<Alternate<AF2>>],
+        rx => [gpiob::PB4<Alternate<AF4>>, gpiod::PD2<Alternate<AF2>>],
+    }
+    USART6 => {
+        tx => [gpioa::PA4<Alternate<AF5>>, gpioc::PC0<Alternate<AF2>>],
+        rx => [gpioa::PA5<Alternate<AF5>>, gpioc::PC1<Alternate<AF2>>],
+    }
 }
 
 /// Serial abstraction

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -108,8 +108,8 @@ usart_pins! {
 #[cfg(feature = "stm32f030xc")]
 usart_pins! {
     USART3 => {
-        // TODO WTF look at this again, in the datasheet PB10 is both tx and rx
-        tx => [/*gpiob::PB10<Alternate<AF4>>,*/ gpioc::PC4<Alternate<AF1>>, gpioc::PC10<Alternate<AF1>>],
+        // According to the datasheet PB10 is both tx and rx, but in stm32cubemx it's only tx
+        tx => [gpiob::PB10<Alternate<AF4>>, gpioc::PC4<Alternate<AF1>>, gpioc::PC10<Alternate<AF1>>],
         rx => [gpiob::PB11<Alternate<AF4>>, gpioc::PC5<Alternate<AF1>>, gpioc::PC11<Alternate<AF1>>],
     }
     USART4 => {

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -176,8 +176,7 @@ usart! {
     USART3: (usart3, usart3en, apb1enr),
     USART4: (usart4, usart4en, apb1enr),
     USART5: (usart5, usart5en, apb1enr),
-    // the usart6en bit is missing
-    // USART6: (usart6, usart6en, apb2enr),
+    USART6: (usart6, usart6en, apb2enr),
 }
 
 // It's s needed for the impls, but rustc doesn't recognize that

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -1,3 +1,4 @@
+use core::ops::Deref;
 use core::ptr;
 
 use nb;
@@ -72,33 +73,62 @@ spi_pins! {
     }
 }
 
+macro_rules! spi {
+    ($($SPI:ident: ($spi:ident, $spiXen:ident, $spiXrst:ident, $apbrstr:ident, $apbenr:ident),)+) => {
+        $(
+            use crate::stm32::$SPI;
+            impl<SCKPIN, MISOPIN, MOSIPIN> Spi<SPI1, SCKPIN, MISOPIN, MOSIPIN> {
+                pub fn $spi<F>(
+                    spi: $SPI,
+                    pins: (SCKPIN, MISOPIN, MOSIPIN),
+                    mode: Mode,
+                    speed: F,
+                    clocks: Clocks,
+                ) -> Self
+                where
+                    SCKPIN: SckPin<$SPI>,
+                    MISOPIN: MisoPin<$SPI>,
+                    MOSIPIN: MosiPin<$SPI>,
+                    F: Into<Hertz>,
+                {
+                    // NOTE(unsafe) This executes only during initialisation
+                    let rcc = unsafe { &(*RCC::ptr()) };
+
+                    /* Enable clock for SPI1 */
+                    rcc.$apbenr.modify(|_, w| w.$spiXen().set_bit());
+
+                    /* Reset SPI1 */
+                    rcc.$apbrstr.modify(|_, w| w.$spiXrst().set_bit());
+                    rcc.$apbrstr.modify(|_, w| w.$spiXrst().clear_bit());
+                    Spi { spi, pins }.spi_init(mode, speed, clocks)
+                }
+            }
+        )+
+    }
+}
 #[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
-impl<SCKPIN, MISOPIN, MOSIPIN> Spi<SPI1, SCKPIN, MISOPIN, MOSIPIN> {
-    pub fn spi1<F>(
-        spi: SPI1,
-        pins: (SCKPIN, MISOPIN, MOSIPIN),
-        mode: Mode,
-        speed: F,
-        clocks: Clocks,
-    ) -> Self
+spi! {
+    SPI1: (spi1, spi1en, spi1rst, apb2enr, apb2rstr),
+}
+#[cfg(any(feature = "stm32f030x8", feature = "stm32f030xc"))]
+spi! {
+    SPI2: (spi2, spi2en, spi2rst, apb1enr, apb1rstr),
+}
+
+// It's s needed for the impls, but rustc doesn't recognize that
+#[allow(dead_code)]
+type SpiRegisterBlock = stm32::spi1::RegisterBlock;
+
+impl<SPI, SCKPIN, MISOPIN, MOSIPIN> Spi<SPI, SCKPIN, MISOPIN, MOSIPIN>
+where
+    SPI: Deref<Target = SpiRegisterBlock>,
+{
+    fn spi_init<F>(self: Self, mode: Mode, speed: F, clocks: Clocks) -> Self
     where
-        SCKPIN: SckPin<SPI1>,
-        MISOPIN: MisoPin<SPI1>,
-        MOSIPIN: MosiPin<SPI1>,
         F: Into<Hertz>,
     {
-        // NOTE(unsafe) This executes only during initialisation
-        let rcc = unsafe { &(*RCC::ptr()) };
-
-        /* Enable clock for SPI1 */
-        rcc.apb2enr.modify(|_, w| w.spi1en().set_bit());
-
-        /* Reset SPI1 */
-        rcc.apb2rstr.modify(|_, w| w.spi1rst().set_bit());
-        rcc.apb2rstr.modify(|_, w| w.spi1rst().clear_bit());
-
         /* Make sure the SPI unit is disabled so we can configure it */
-        spi.cr1.modify(|_, w| w.spe().clear_bit());
+        self.spi.cr1.modify(|_, w| w.spe().clear_bit());
 
         // FRXTH: 8-bit threshold on RX FIFO
         // DS: 8-bit data size
@@ -106,7 +136,8 @@ impl<SCKPIN, MISOPIN, MOSIPIN> Spi<SPI1, SCKPIN, MISOPIN, MOSIPIN> {
         //
         // NOTE(unsafe): DS reserved bit patterns are 0b0000, 0b0001, and 0b0010. 0b0111 is valid
         // (reference manual, pp 804)
-        spi.cr2
+        self.spi
+            .cr2
             .write(|w| unsafe { w.frxth().set_bit().ds().bits(0b0111).ssoe().clear_bit() });
 
         let br = match clocks.pclk().0 / speed.into().0 {
@@ -128,7 +159,7 @@ impl<SCKPIN, MISOPIN, MOSIPIN> Spi<SPI1, SCKPIN, MISOPIN, MOSIPIN> {
         // dff: 8 bit frames
         // bidimode: 2-line unidirectional
         // spe: enable the SPI bus
-        spi.cr1.write(|w| unsafe {
+        self.spi.cr1.write(|w| unsafe {
             w.cpha()
                 .bit(mode.phase == Phase::CaptureOnSecondTransition)
                 .cpol()
@@ -151,17 +182,17 @@ impl<SCKPIN, MISOPIN, MOSIPIN> Spi<SPI1, SCKPIN, MISOPIN, MOSIPIN> {
                 .set_bit()
         });
 
-        Spi { spi, pins }
+        self
     }
-
-    pub fn release(self) -> (SPI1, (SCKPIN, MISOPIN, MOSIPIN)) {
+    pub fn release(self) -> (SPI, (SCKPIN, MISOPIN, MOSIPIN)) {
         (self.spi, self.pins)
     }
 }
 
-#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
-impl<SCKPIN, MISOPIN, MOSIPIN> ::embedded_hal::spi::FullDuplex<u8>
-    for Spi<SPI1, SCKPIN, MISOPIN, MOSIPIN>
+impl<SPI, SCKPIN, MISOPIN, MOSIPIN> ::embedded_hal::spi::FullDuplex<u8>
+    for Spi<SPI, SCKPIN, MISOPIN, MOSIPIN>
+where
+    SPI: Deref<Target = SpiRegisterBlock>,
 {
     type Error = Error;
 
@@ -202,13 +233,15 @@ impl<SCKPIN, MISOPIN, MOSIPIN> ::embedded_hal::spi::FullDuplex<u8>
     }
 }
 
-#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
-impl<SCKPIN, MISOPIN, MOSIPIN> ::embedded_hal::blocking::spi::transfer::Default<u8>
-    for Spi<SPI1, SCKPIN, MISOPIN, MOSIPIN>
+impl<SPI, SCKPIN, MISOPIN, MOSIPIN> ::embedded_hal::blocking::spi::transfer::Default<u8>
+    for Spi<SPI, SCKPIN, MISOPIN, MOSIPIN>
+where
+    SPI: Deref<Target = SpiRegisterBlock>,
 {
 }
-#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
-impl<SCKPIN, MISOPIN, MOSIPIN> ::embedded_hal::blocking::spi::write::Default<u8>
-    for Spi<SPI1, SCKPIN, MISOPIN, MOSIPIN>
+impl<SPI, SCKPIN, MISOPIN, MOSIPIN> ::embedded_hal::blocking::spi::write::Default<u8>
+    for Spi<SPI, SCKPIN, MISOPIN, MOSIPIN>
+where
+    SPI: Deref<Target = SpiRegisterBlock>,
 {
 }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -76,6 +76,22 @@ spi_pins! {
         mosi => [gpiob::PB15<Alternate<AF0>>],
     }
 }
+#[cfg(any(feature = "stm32f030x8", feature = "stm32f030xc"))]
+spi_pins! {
+    SPI2 => {
+        sck => [gpiob::PB13<Alternate<AF0>>],
+        miso => [gpiob::PB14<Alternate<AF0>>],
+        mosi => [gpiob::PB15<Alternate<AF0>>],
+    }
+}
+#[cfg(feature = "stm32f030xc")]
+spi_pins! {
+    SPI2 => {
+        sck => [gpiob::PB10<Alternate<AF5>>],
+        miso => [gpioc::PC2<Alternate<AF1>>],
+        mosi => [gpioc::PC3<Alternate<AF1>>],
+    }
+}
 
 macro_rules! spi {
     ($($SPI:ident: ($spi:ident, $spiXen:ident, $spiXrst:ident, $apbenr:ident, $apbrstr:ident),)+) => {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -4,6 +4,7 @@ use nb;
 
 pub use embedded_hal::spi::{Mode, Phase, Polarity};
 
+use crate::stm32;
 #[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
 use crate::stm32::{RCC, SPI1};
 
@@ -25,45 +26,65 @@ pub enum Error {
 }
 
 /// SPI abstraction
-pub struct Spi<SPI, PINS> {
+pub struct Spi<SPI, SCKPIN, MISOPIN, MOSIPIN> {
     spi: SPI,
-    pins: PINS,
+    pins: (SCKPIN, MISOPIN, MOSIPIN),
 }
 
-pub trait Pins<Spi> {}
+pub trait SckPin<SPI> {}
+pub trait MisoPin<SPI> {}
+pub trait MosiPin<SPI> {}
+
+macro_rules! spi_pins {
+    ($($SPI:ident => {
+        sck => [$($sck:ty),+ $(,)*],
+        miso => [$($miso:ty),+ $(,)*],
+        mosi => [$($mosi:ty),+ $(,)*],
+    })+) => {
+        $(
+            $(
+                impl SckPin<stm32::$SPI> for $sck {}
+            )+
+            $(
+                impl MisoPin<stm32::$SPI> for $miso {}
+            )+
+            $(
+                impl MosiPin<stm32::$SPI> for $mosi {}
+            )+
+        )+
+    }
+}
 
 #[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
-impl Pins<SPI1>
-    for (
-        gpioa::PA5<Alternate<AF0>>,
-        gpioa::PA6<Alternate<AF0>>,
-        gpioa::PA7<Alternate<AF0>>,
-    )
-{}
-#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
-impl Pins<SPI1>
-    for (
-        gpiob::PB3<Alternate<AF0>>,
-        gpiob::PB4<Alternate<AF0>>,
-        gpiob::PB5<Alternate<AF0>>,
-    )
-{}
-
+spi_pins! {
+    SPI1 => {
+        sck => [gpioa::PA5<Alternate<AF0>>, gpiob::PB3<Alternate<AF0>>],
+        miso => [gpioa::PA6<Alternate<AF0>>, gpiob::PB4<Alternate<AF0>>],
+        mosi => [gpioa::PA7<Alternate<AF0>>, gpiob::PB5<Alternate<AF0>>],
+    }
+}
 #[cfg(feature = "stm32f030x6")]
-impl Pins<SPI1>
-    for (
-        gpiob::PB13<Alternate<AF0>>,
-        gpiob::PB14<Alternate<AF0>>,
-        gpiob::PB15<Alternate<AF0>>,
-    )
-{
+spi_pins! {
+    SPI1 => {
+        sck => [gpiob::PB13<Alternate<AF0>>],
+        miso => [gpiob::PB14<Alternate<AF0>>],
+        mosi => [gpiob::PB15<Alternate<AF0>>],
+    }
 }
 
 #[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
-impl<PINS> Spi<SPI1, PINS> {
-    pub fn spi1<F>(spi: SPI1, pins: PINS, mode: Mode, speed: F, clocks: Clocks) -> Self
+impl<SCKPIN, MISOPIN, MOSIPIN> Spi<SPI1, SCKPIN, MISOPIN, MOSIPIN> {
+    pub fn spi1<F>(
+        spi: SPI1,
+        pins: (SCKPIN, MISOPIN, MOSIPIN),
+        mode: Mode,
+        speed: F,
+        clocks: Clocks,
+    ) -> Self
     where
-        PINS: Pins<SPI1>,
+        SCKPIN: SckPin<SPI1>,
+        MISOPIN: MisoPin<SPI1>,
+        MOSIPIN: MosiPin<SPI1>,
         F: Into<Hertz>,
     {
         // NOTE(unsafe) This executes only during initialisation
@@ -133,13 +154,15 @@ impl<PINS> Spi<SPI1, PINS> {
         Spi { spi, pins }
     }
 
-    pub fn release(self) -> (SPI1, PINS) {
+    pub fn release(self) -> (SPI1, (SCKPIN, MISOPIN, MOSIPIN)) {
         (self.spi, self.pins)
     }
 }
 
 #[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
-impl<PINS> ::embedded_hal::spi::FullDuplex<u8> for Spi<SPI1, PINS> {
+impl<SCKPIN, MISOPIN, MOSIPIN> ::embedded_hal::spi::FullDuplex<u8>
+    for Spi<SPI1, SCKPIN, MISOPIN, MOSIPIN>
+{
     type Error = Error;
 
     fn read(&mut self) -> nb::Result<u8, Error> {
@@ -180,6 +203,12 @@ impl<PINS> ::embedded_hal::spi::FullDuplex<u8> for Spi<SPI1, PINS> {
 }
 
 #[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
-impl<PINS> ::embedded_hal::blocking::spi::transfer::Default<u8> for Spi<SPI1, PINS> {}
+impl<SCKPIN, MISOPIN, MOSIPIN> ::embedded_hal::blocking::spi::transfer::Default<u8>
+    for Spi<SPI1, SCKPIN, MISOPIN, MOSIPIN>
+{
+}
 #[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
-impl<PINS> ::embedded_hal::blocking::spi::write::Default<u8> for Spi<SPI1, PINS> {}
+impl<SCKPIN, MISOPIN, MOSIPIN> ::embedded_hal::blocking::spi::write::Default<u8>
+    for Spi<SPI1, SCKPIN, MISOPIN, MOSIPIN>
+{
+}

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -4,7 +4,7 @@ use nb;
 
 pub use embedded_hal::spi::{Mode, Phase, Polarity};
 
-#[cfg(feature = "stm32f042")]
+#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
 use crate::stm32::{RCC, SPI1};
 
 use crate::gpio::*;
@@ -32,7 +32,7 @@ pub struct Spi<SPI, PINS> {
 
 pub trait Pins<Spi> {}
 
-#[cfg(feature = "stm32f042")]
+#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
 impl Pins<SPI1>
     for (
         gpioa::PA5<Alternate<AF0>>,
@@ -40,7 +40,7 @@ impl Pins<SPI1>
         gpioa::PA7<Alternate<AF0>>,
     )
 {}
-#[cfg(feature = "stm32f042")]
+#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
 impl Pins<SPI1>
     for (
         gpiob::PB3<Alternate<AF0>>,
@@ -49,7 +49,17 @@ impl Pins<SPI1>
     )
 {}
 
-#[cfg(feature = "stm32f042")]
+#[cfg(feature = "stm32f030x6")]
+impl Pins<SPI1>
+    for (
+        gpiob::PB13<Alternate<AF0>>,
+        gpiob::PB14<Alternate<AF0>>,
+        gpiob::PB15<Alternate<AF0>>,
+    )
+{
+}
+
+#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
 impl<PINS> Spi<SPI1, PINS> {
     pub fn spi1<F>(spi: SPI1, pins: PINS, mode: Mode, speed: F, clocks: Clocks) -> Self
     where
@@ -128,7 +138,7 @@ impl<PINS> Spi<SPI1, PINS> {
     }
 }
 
-#[cfg(feature = "stm32f042")]
+#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
 impl<PINS> ::embedded_hal::spi::FullDuplex<u8> for Spi<SPI1, PINS> {
     type Error = Error;
 
@@ -169,7 +179,7 @@ impl<PINS> ::embedded_hal::spi::FullDuplex<u8> for Spi<SPI1, PINS> {
     }
 }
 
-#[cfg(feature = "stm32f042")]
+#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
 impl<PINS> ::embedded_hal::blocking::spi::transfer::Default<u8> for Spi<SPI1, PINS> {}
-#[cfg(feature = "stm32f042")]
+#[cfg(any(feature = "stm32f042", feature = "stm32f030"))]
 impl<PINS> ::embedded_hal::blocking::spi::write::Default<u8> for Spi<SPI1, PINS> {}

--- a/src/timers.rs
+++ b/src/timers.rs
@@ -24,10 +24,7 @@
 //! }
 //! ```
 
-#[cfg(feature = "stm32f030")]
-use crate::stm32::{RCC, TIM1, TIM14, TIM15, TIM16, TIM17, TIM3, TIM6, TIM7};
-#[cfg(feature = "stm32f042")]
-use crate::stm32::{RCC, TIM1, TIM14, TIM16, TIM17, TIM2, TIM3};
+use crate::stm32;
 use cortex_m::peripheral::syst::SystClkSource;
 use cortex_m::peripheral::SYST;
 
@@ -111,6 +108,7 @@ impl Periodic for Timer<SYST> {}
 macro_rules! timers {
     ($($TIM:ident: ($tim:ident, $timXen:ident, $timXrst:ident, $apbenr:ident, $apbrstr:ident),)+) => {
         $(
+            use crate::stm32::$TIM;
             impl Timer<$TIM> {
                 // XXX(why not name this `new`?) bummer: constructors need to have different names
                 // even if the `$TIM` are non overlapping (compare to the `free` function below
@@ -121,7 +119,7 @@ macro_rules! timers {
                     T: Into<Hertz>,
                 {
                     // NOTE(unsafe) This executes only during initialisation
-                    let rcc = unsafe { &(*RCC::ptr()) };
+                    let rcc = unsafe { &(*stm32::RCC::ptr()) };
 
                     // enable and reset peripheral to a clean slate state
                     rcc.$apbenr.modify(|_, w| w.$timXen().set_bit());
@@ -159,8 +157,7 @@ macro_rules! timers {
 
                 /// Releases the TIM peripheral
                 pub fn release(self) -> $TIM {
-                    use crate::stm32::RCC;
-                    let rcc = unsafe { &(*RCC::ptr()) };
+                    let rcc = unsafe { &(*stm32::RCC::ptr()) };
                     // Pause counter
                     self.tim.cr1.modify(|_, w| w.cen().clear_bit());
                     // Disable timer


### PR DESCRIPTION
- Serial is now structured like in https://github.com/stm32-rs/stm32f4xx-hal/pull/48/, so there is no giant macro repeating code
- I2C1 & I2C2 is there
- SPI1 & SPI2 is there

### TODO
- (Maybe) Port examples so they work on all variants (Opened a separate issue for that)

