### PR TITLE
Allow multi delay instances for the systick timer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+- Added the option to have multiple Delay instances by cloning it - @david-sawatzke
+
 ## [v0.10.1] - 2018-12-25
 
 ### Added

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -82,7 +82,7 @@ impl DelayUs<u32> for Delay {
         const MAX_RVR: u32 = 0x00FF_FFFF;
 
         let mut total_rvr = if self.clocks.sysclk().0 < 1_000_000 {
-            us / (1_000_00 / self.clocks.sysclk().0)
+            us / (1_000_000 / self.clocks.sysclk().0)
         } else {
             us * (self.clocks.sysclk().0 / 1_000_000)
         };

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -38,6 +38,8 @@ pub struct Delay {
     clocks: Clocks,
 }
 
+const MAX_SYSTICK: u32 = 0x00FF_FFFF;
+
 impl Delay {
     /// Configures the system timer (SysTick) as a delay provider
     /// As access to the count register is possible without a reference, we can
@@ -45,7 +47,7 @@ impl Delay {
     pub fn new(mut syst: SYST, clocks: Clocks) -> Delay {
         syst.set_clock_source(SystClkSource::Core);
 
-        syst.set_reload(0x00FF_FFFF);
+        syst.set_reload(MAX_SYSTICK);
         syst.clear_current();
         syst.enable_counter();
         Delay { clocks }
@@ -96,9 +98,8 @@ impl DelayUs<u32> for Delay {
             };
 
             let start_count = SYST::get_current();
-            while (SYST::get_current() - start_count) < current_rvr {}
-            // Update the tracking variable while we are waiting...
             total_rvr -= current_rvr;
+            while ((start_count - SYST::get_current()) % MAX_SYSTICK) < current_rvr {}
         }
     }
 }


### PR DESCRIPTION
A lot of device crates need a delay instances, see https://github.com/JohnDoneth/hd44780-driver and https://github.com/yuri91/ili9341-rs. Having to pass a delay instance as needed isn't very ergonomic. I think multiple delay instances are often needed. There are multiple ways to do this (that I can think of):

- Allow a delay instance based on asm delay loops (probably needs ramfunc because of wait states)
- Allow normal timers to be used for delays
- Allow multiple instances using the systick timer read only 

I used the last way, leaving the systick always running, getting the timer value at the beginning and comparing it to the current one (including some amount of leeway so that long interrupts can't easily overflow). The first commit also fixes #21 (just a typo). We technically don't need an instance after init,  but if the user were to reconfigure the timer, the delay would break.