### PR TITLE
Add badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 stm32f0xx-hal
 =============
+[![Travis](https://img.shields.io/travis/stm32-rs/stm32f0xx-hal.svg)](https://travis-ci.org/stm32-rs/stm32f0xx-hal)
+[![Crates.io](https://img.shields.io/crates/v/stm32f0xx-hal.svg)](https://crates.io/crates/stm32f0xx-hal)
+[![docs.rs](https://docs.rs/stm32f0xx-hal/badge.svg)](https://docs.rs/stm32f0xx-hal/)
 
 _stm32f0xx-hal_ contains a hardware abstraction on top of the peripheral access
 API for the STMicro STM32F0xx family of microcontrollers. It replaces the


### PR DESCRIPTION
Simple PR that adds travis, crates.io and docs.rs badges to the README.