### PR TITLE
Add a tx only and a rx only serial instance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Support for stm32f0x1 line - @jessebraham
 - Support for HSE as a system clocksource (#25 - breaking change) - @zklapow
+- Add ability to use a Tx/Rx only serial instance - @david-sawatzke
 
 ### Changed
 

--- a/examples/serial_echo.rs
+++ b/examples/serial_echo.rs
@@ -26,13 +26,11 @@ fn main() -> ! {
             let tx = gpioa.pa9.into_alternate_af1(cs);
             let rx = gpioa.pa10.into_alternate_af1(cs);
 
-            let serial = Serial::usart1(p.USART1, (tx, rx), 115_200.bps(), &mut rcc);
-
-            let (mut tx, mut rx) = serial.split();
+            let mut serial = Serial::usart1(p.USART1, (tx, rx), 115_200.bps(), &mut rcc);
 
             loop {
-                let received = block!(rx.read()).unwrap();
-                block!(tx.write(received)).ok();
+                let received = block!(serial.read()).unwrap();
+                block!(serial.write(received)).ok();
             }
         });
     }

--- a/examples/watchdog.rs
+++ b/examples/watchdog.rs
@@ -36,12 +36,10 @@ fn main() -> ! {
             let mut delay = Delay::new(cp.SYST, &rcc);
 
             let tx = gpioa.pa9.into_alternate_af1(cs);
-            let rx = gpioa.pa10.into_alternate_af1(cs);
 
-            let serial = Serial::usart1(p.USART1, (tx, rx), 115_200.bps(), &mut rcc);
+            let mut serial = Serial::usart1tx(p.USART1, tx, 115_200.bps(), &mut rcc);
 
-            let (mut tx, _rx) = serial.split();
-            tx.write_str("RESET \r\n").ok();
+            serial.write_str("RESET \r\n").ok();
 
             watchdog.start(Hertz(1));
             delay.delay_ms(500_u16);
@@ -49,12 +47,12 @@ fn main() -> ! {
             delay.delay_ms(500_u16);
             watchdog.feed();
             delay.delay_ms(500_u16);
-            tx.write_str("This will get printed \r\n").ok();
+            serial.write_str("This will get printed \r\n").ok();
             watchdog.feed();
 
             // Now a reset happens while delaying
             delay.delay_ms(1500_u16);
-            tx.write_str("This won't\r\n").ok();
+            serial.write_str("This won't\r\n").ok();
         });
     }
 


### PR DESCRIPTION
This also makes the serial stuff in https://github.com/stm32-rs/stm32f0xx-hal/pull/27 obsolete. 
Additionally by virtue of how it works also implements https://github.com/stm32-rs/stm32f4xx-hal/pull/49 here.

Not sure how we should handle the release method. It currently works but you get a `()` for the unused pin back.

Currently untested