### PR TITLE
Add support for the STM32f091

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,9 @@ env:
   - MCU=stm32f070x6
   - MCU=stm32f070xb
   - MCU=stm32f072
+  - MCU=stm32f091
+  - MCU=stm32f091xb
+  - MCU=stm32f091xc
 matrix:
   allow_failures:
     - rust: nightly

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,8 +14,6 @@ env:
   - MCU=stm32f070xb
   - MCU=stm32f072
   - MCU=stm32f091
-  - MCU=stm32f091xb
-  - MCU=stm32f091xc
 matrix:
   allow_failures:
     - rust: nightly

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Support for STM32F091 - @jessebraham
+
 ## [v0.11.1] - 2019-01-05
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -56,6 +56,9 @@ stm32f070 = ["stm32f0/stm32f0x0", "device-selected"]
 stm32f070x6 = ["stm32f070"]
 stm32f070xb = ["stm32f070"]
 stm32f072 = ["stm32f0/stm32f0x2", "device-selected"]
+stm32f091 = ["stm32f0/stm32f0x1", "device-selected"]
+stm32f091xb = ["stm32f091"]
+stm32f091xc = ["stm32f091"]
 
 [profile.dev]
 debug = true

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,8 +57,6 @@ stm32f070x6 = ["stm32f070"]
 stm32f070xb = ["stm32f070"]
 stm32f072 = ["stm32f0/stm32f0x2", "device-selected"]
 stm32f091 = ["stm32f0/stm32f0x1", "device-selected"]
-stm32f091xb = ["stm32f091"]
-stm32f091xc = ["stm32f091"]
 
 [profile.dev]
 debug = true

--- a/README.md
+++ b/README.md
@@ -20,8 +20,6 @@ Currently supported configuration are:
 * stm32f070xb
 * stm32f072
 * stm32f091
-* stm32f091xb
-* stm32f091xc
 
 The idea behind this crate is to gloss over the slight differences in the
 various peripherals available on those MCUs so a HAL can be written for all

--- a/README.md
+++ b/README.md
@@ -19,6 +19,9 @@ Currently supported configuration are:
 * stm32f070x6
 * stm32f070xb
 * stm32f072
+* stm32f091
+* stm32f091xb
+* stm32f091xc
 
 The idea behind this crate is to gloss over the slight differences in the
 various peripherals available on those MCUs so a HAL can be written for all

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -219,7 +219,8 @@ adc_pins!(
 #[cfg(any(
     feature = "stm32f030",
     feature = "stm32f070",
-    feature = "stm32f072"
+    feature = "stm32f072",
+    feature = "stm32f091"
 ))]
 adc_pins!(
     gpioc::PC0<Analog> => 10_u8,
@@ -364,17 +365,17 @@ impl VRef {
     }
 }
 
-#[cfg(any(feature = "stm32f042", feature = "stm32f072"))]
+#[cfg(any(feature = "stm32f042", feature = "stm32f072", feature = "stm32f091"))]
 #[derive(Debug, Default)]
 /// Battery reference voltage (ADC Channel 18)
 pub struct VBat;
 
-#[cfg(any(feature = "stm32f042", feature = "stm32f072"))]
+#[cfg(any(feature = "stm32f042", feature = "stm32f072", feature = "stm32f091"))]
 adc_pins!(
     VBat  => 18_u8,
 );
 
-#[cfg(any(feature = "stm32f042", feature = "stm32f072"))]
+#[cfg(any(feature = "stm32f042", feature = "stm32f072", feature = "stm32f091"))]
 impl VBat {
     /// Init a new VBat
     pub fn new() -> Self {

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -577,7 +577,8 @@ gpio!(GPIOC, gpioc, iopcen, PC, [
 #[cfg(any(
     feature = "stm32f030",
     feature = "stm32f070",
-    feature = "stm32f072"
+    feature = "stm32f072",
+    feature = "stm32f091",
 ))]
 gpio!(GPIOC, gpioc, iopcen, PC, [
     PC0: (pc0, 0, Input<Floating>),
@@ -598,15 +599,12 @@ gpio!(GPIOC, gpioc, iopcen, PC, [
     PC15: (pc15, 15, Input<Floating>),
 ]);
 
-#[cfg(any(
-    feature = "stm32f030",
-    feature = "stm32f070"
-))]
+#[cfg(any(feature = "stm32f030", feature = "stm32f070"))]
 gpio!(GPIOD, gpiod, iopden, PD, [
     PD2: (pd2, 2, Input<Floating>),
 ]);
 
-#[cfg(feature = "stm32f072")]
+#[cfg(any(feature = "stm32f072", feature = "stm32f091"))]
 gpio!(GPIOD, gpiod, iopden, PD, [
     PD0: (pd0, 0, Input<Floating>),
     PD1: (pd1, 1, Input<Floating>),
@@ -629,7 +627,7 @@ gpio!(GPIOD, gpiod, iopden, PD, [
 // TODO: The ST SVD files are missing the entire PE enable register.
 //       Re-enable as soon as this gets fixed.
 
-// #[cfg(feature = "stm32f072")]
+// #[cfg(any(feature = "stm32f072", feature = "stm32f091"))]
 // gpio!(GPIOE, gpioe, iopeen, PE, [
 //     PE0: (pe0, 0, Input<Floating>),
 //     PE1: (pe1, 1, Input<Floating>),
@@ -672,7 +670,7 @@ gpio!(GPIOF, gpiof, iopfen, PF, [
     PF1: (pf1, 1, Input<Floating>),
 ]);
 
-#[cfg(feature = "stm32f072")]
+#[cfg(any(feature = "stm32f072", feature = "stm32f091"))]
 gpio!(GPIOF, gpiof, iopfen, PF, [
     PF0: (pf0, 0, Input<Floating>),
     PF1: (pf1, 1, Input<Floating>),

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -48,6 +48,7 @@ i2c_pins! {
     feature = "stm32f030x6",
     feature = "stm32f030xc",
     feature = "stm32f042",
+    feature = "stm32f091",
 ))]
 i2c_pins! {
     I2C1 => {
@@ -69,7 +70,7 @@ i2c_pins! {
         sda => [gpiob::PB14<Alternate<AF5>>, gpiof::PF0<Alternate<AF1>>],
     }
 }
-#[cfg(any(feature = "stm32f070", feature = "stm32f072"))]
+#[cfg(any(feature = "stm32f070", feature = "stm32f072", feature = "stm32f091"))]
 i2c_pins! {
     I2C1 => {
         scl => [gpiob::PB6<Alternate<AF1>>, gpiob::PB8<Alternate<AF1>>],
@@ -83,6 +84,13 @@ i2c_pins! {
         sda => [gpioa::PA10<Alternate<AF4>>, gpiof::PF1<Alternate<AF1>>],
     }
 }
+#[cfg(feature = "stm32f091")]
+i2c_pins! {
+    I2C1 => {
+        scl => [gpiof::PF1<Alternate<AF1>>],
+        sda => [gpiof::PF0<Alternate<AF1>>],
+    }
+}
 
 #[cfg(any(feature = "stm32f030x8"))]
 i2c_pins! {
@@ -91,11 +99,23 @@ i2c_pins! {
         sda => [gpiob::PB11<Alternate<AF1>>],
     }
 }
-#[cfg(any(feature = "stm32f030xc", feature = "stm32f070xb", feature = "stm32f072"))]
+#[cfg(any(
+    feature = "stm32f030xc",
+    feature = "stm32f070xb",
+    feature = "stm32f072",
+    feature = "stm32f091",
+))]
 i2c_pins! {
     I2C2 => {
         scl => [gpiob::PB10<Alternate<AF1>>, gpiob::PB13<Alternate<AF5>>],
         sda => [gpiob::PB11<Alternate<AF1>>, gpiob::PB14<Alternate<AF5>>],
+    }
+}
+#[cfg(feature = "stm32f091")]
+i2c_pins! {
+    I2C2 => {
+        scl => [gpioa::PA11<Alternate<AF5>>],
+        sda => [gpioa::PA12<Alternate<AF5>>],
     }
 }
 
@@ -142,7 +162,8 @@ i2c! {
     // XXX: This can't be right
     feature = "stm32f030xc",
     feature = "stm32f070xb",
-    feature = "stm32f072"
+    feature = "stm32f072",
+    feature = "stm32f091",
 ))]
 i2c! {
     I2C2: (i2c2, i2c2en, i2c2rst, apb1enr, apb1rstr),

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -3,11 +3,14 @@
 
 pub use stm32f0;
 
-#[cfg(any(feature = "stm32f042", feature = "stm32f072"))]
-pub use stm32f0::stm32f0x2 as stm32;
-
 #[cfg(any(feature = "stm32f030", feature = "stm32f070"))]
 pub use stm32f0::stm32f0x0 as stm32;
+
+#[cfg(feature = "stm32f091")]
+pub use stm32f0::stm32f0x1 as stm32;
+
+#[cfg(any(feature = "stm32f042", feature = "stm32f072"))]
+pub use stm32f0::stm32f0x2 as stm32;
 
 pub mod adc;
 pub mod delay;

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -87,7 +87,7 @@ impl CFGR {
         self
     }
 
-    #[cfg(feature = "stm32f042")]
+    #[cfg(any(feature = "stm32f042", feature = "stm32f091"))]
     pub fn enable_hsi48(mut self, is_enabled: bool) -> Self {
         self.enable_hsi48 = is_enabled;
         self

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -169,17 +169,17 @@ usart_pins! {
 }
 // TODO: The ST SVD files are missing the entire PE enable register.
 //       Re-enable as soon as this gets fixed.
-// #[cfg(feature = "stm32f091")]
-// usart_pins! {
-//     USART5 => {
-//         tx => [gpioe::PE10<Alternate<AF1>>],
-//         rx => [gpioe::PE11<Alternate<AF1>>],
-//     }
-//     USART6 => {
-//         tx => [gpiof::PF9<Alternate<AF1>>],
-//         rx => [gpiof::PF10<Alternate<AF1>>],
-//     }
-// }
+#[cfg(feature = "stm32f091")]
+usart_pins! {
+    // USART5 => {
+    //     tx => [gpioe::PE10<Alternate<AF1>>],
+    //     rx => [gpioe::PE11<Alternate<AF1>>],
+    // }
+    USART6 => {
+        tx => [gpiof::PF9<Alternate<AF1>>],
+        rx => [gpiof::PF10<Alternate<AF1>>],
+    }
+}
 
 /// Serial abstraction
 #[allow(unused)]

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -95,7 +95,7 @@ usart_pins! {
         rx => [gpioa::PA3<Alternate<AF1>>, gpioa::PA15<Alternate<AF1>>],
     }
 }
-#[cfg(any(feature = "stm32f070", feature = "stm32f072"))]
+#[cfg(any(feature = "stm32f070", feature = "stm32f072", feature = "stm32f091"))]
 usart_pins! {
     USART1 => {
         tx => [gpioa::PA9<Alternate<AF1>>, gpiob::PB6<Alternate<AF0>>],
@@ -108,6 +108,7 @@ usart_pins! {
     feature = "stm32f042",
     feature = "stm32f070",
     feature = "stm32f072",
+    feature = "stm32f091",
 ))]
 usart_pins! {
     USART2 => {
@@ -115,7 +116,7 @@ usart_pins! {
         rx => [gpioa::PA3<Alternate<AF1>>, gpioa::PA15<Alternate<AF1>>],
     }
 }
-#[cfg(feature = "stm32f072")]
+#[cfg(any(feature = "stm32f072", feature = "stm32f091"))]
 usart_pins! {
     USART2 => {
         tx => [gpiod::PD5<Alternate<AF0>>],
@@ -125,7 +126,8 @@ usart_pins! {
 #[cfg(any(
     feature = "stm32f030xc",
     feature = "stm32f070xb",
-    feature = "stm32f072"
+    feature = "stm32f072",
+    feature = "stm32f091",
 ))]
 usart_pins! {
     USART3 => {
@@ -138,14 +140,23 @@ usart_pins! {
         rx => [gpioa::PA1<Alternate<AF4>>, gpioc::PC11<Alternate<AF0>>],
     }
 }
-#[cfg(feature = "stm32f072")]
+#[cfg(any(feature = "stm32f072", feature = "stm32f091"))]
 usart_pins! {
     USART3 => {
         tx => [gpiod::PD8<Alternate<AF0>>],
         rx => [gpiod::PD9<Alternate<AF0>>],
     }
 }
-#[cfg(feature = "stm32f030xc")]
+// TODO: The ST SVD files are missing the entire PE enable register.
+//       Re-enable as soon as this gets fixed.
+// #[cfg(feature = "stm32f091")]
+// usart_pins! {
+//     USART4 => {
+//         tx => [gpioe::PE8<Alternate<AF1>>],
+//         rx => [gpioe::PE9<Alternate<AF1>>],
+//     }
+// }
+#[cfg(any(feature = "stm32f030xc", feature = "stm32f091"))]
 usart_pins! {
     USART5 => {
         tx => [gpiob::PB3<Alternate<AF4>>, gpioc::PC12<Alternate<AF2>>],
@@ -156,6 +167,19 @@ usart_pins! {
         rx => [gpioa::PA5<Alternate<AF5>>, gpioc::PC1<Alternate<AF2>>],
     }
 }
+// TODO: The ST SVD files are missing the entire PE enable register.
+//       Re-enable as soon as this gets fixed.
+// #[cfg(feature = "stm32f091")]
+// usart_pins! {
+//     USART5 => {
+//         tx => [gpioe::PE10<Alternate<AF1>>],
+//         rx => [gpioe::PE11<Alternate<AF1>>],
+//     }
+//     USART6 => {
+//         tx => [gpiof::PF9<Alternate<AF1>>],
+//         rx => [gpiof::PF10<Alternate<AF1>>],
+//     }
+// }
 
 /// Serial abstraction
 #[allow(unused)]
@@ -260,6 +284,7 @@ usart! {
     feature = "stm32f042",
     feature = "stm32f070",
     feature = "stm32f072",
+    feature = "stm32f091",
 ))]
 usart! {
     USART2: (usart2, usart2en, apb1enr),
@@ -268,12 +293,13 @@ usart! {
     feature = "stm32f030xc",
     feature = "stm32f070xb",
     feature = "stm32f072",
+    feature = "stm32f091",
 ))]
 usart! {
     USART3: (usart3, usart3en, apb1enr),
     USART4: (usart4, usart4en, apb1enr),
 }
-#[cfg(feature = "stm32f030xc")]
+#[cfg(any(feature = "stm32f030xc", feature = "stm32f091"))]
 usart! {
     USART5: (usart5, usart5en, apb1enr),
     USART6: (usart6, usart6en, apb2enr),

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -15,6 +15,7 @@ use crate::stm32::SPI1;
     feature = "stm32f030xc",
     feature = "stm32f070xb",
     feature = "stm32f072",
+    feature = "stm32f091",
 ))]
 use crate::stm32::SPI2;
 
@@ -88,11 +89,10 @@ spi_pins! {
         mosi => [gpiob::PB15<Alternate<AF0>>],
     }
 }
-
 // TODO: The ST SVD files are missing the entire PE enable register.
 //       So those pins do not exist in the register definitions.
 //       Re-enable as soon as this gets fixed.
-// #[cfg(feature = "stm32f072")]
+// #[cfg(any(feature = "stm32f072", feature = "stm32f091"))]
 // spi_pins! {
 //     SPI1 => {
 //         sck => [gpioe::PE13<Alternate<AF1>>],
@@ -100,11 +100,13 @@ spi_pins! {
 //         mosi => [gpioe::PE15<Alternate<AF1>>],
 //     }
 // }
+
 #[cfg(any(
     feature = "stm32f030x8",
     feature = "stm32f030xc",
     feature = "stm32f070xb",
     feature = "stm32f072",
+    feature = "stm32f091",
 ))]
 spi_pins! {
     SPI2 => {
@@ -117,6 +119,7 @@ spi_pins! {
     feature = "stm32f030xc",
     feature = "stm32f070xb",
     feature = "stm32f072",
+    feature = "stm32f091",
 ))]
 spi_pins! {
     SPI2 => {
@@ -125,7 +128,7 @@ spi_pins! {
         mosi => [gpioc::PC3<Alternate<AF1>>],
     }
 }
-#[cfg(feature = "stm32f072")]
+#[cfg(any(feature = "stm32f072", feature = "stm32f091"))]
 spi_pins! {
     SPI2 => {
         sck => [gpiod::PD1<Alternate<AF1>>],
@@ -175,7 +178,8 @@ spi! {
 #[cfg(any(
     feature = "stm32f030x8",
     feature = "stm32f030xc",
-    feature = "stm32f070xb"
+    feature = "stm32f070xb",
+    feature = "stm32f091",
 ))]
 spi! {
     SPI2: (spi2, spi2en, spi2rst, apb1enr, apb1rstr),

--- a/src/timers.rs
+++ b/src/timers.rs
@@ -225,6 +225,7 @@ timers! {
     feature = "stm32f030xc",
     feature = "stm32f070xb",
     feature = "stm32f072",
+    feature = "stm32f091",
 ))]
 timers! {
     TIM6: (tim6, tim6en, tim6rst, apb1enr, apb1rstr),
@@ -235,12 +236,13 @@ timers! {
     feature = "stm32f030xc",
     feature = "stm32f070xb",
     feature = "stm32f072",
+    feature = "stm32f091",
 ))]
 timers! {
     TIM7: (tim7, tim7en, tim7rst, apb1enr, apb1rstr),
 }
 
-#[cfg(any(feature = "stm32f042", feature = "stm32f072"))]
+#[cfg(any(feature = "stm32f042", feature = "stm32f072", feature = "stm32f091"))]
 timers! {
     TIM2: (tim2, tim2en, tim2rst, apb1enr, apb1rstr),
 }


### PR DESCRIPTION
Adds device support for the [STM32F091](https://www.st.com/en/microcontrollers/stm32f0x1.html?querycriteria=productId=LN7). Let me know if anything needs fixing.