### PR TITLE
Overhaul README, add Getting Started section

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,46 +1,47 @@
 stm32f0xx-hal
 =============
+
 [![Travis](https://img.shields.io/travis/stm32-rs/stm32f0xx-hal.svg)](https://travis-ci.org/stm32-rs/stm32f0xx-hal)
 [![Crates.io](https://img.shields.io/crates/v/stm32f0xx-hal.svg)](https://crates.io/crates/stm32f0xx-hal)
 [![docs.rs](https://docs.rs/stm32f0xx-hal/badge.svg)](https://docs.rs/stm32f0xx-hal/)
 
-_stm32f0xx-hal_ contains a hardware abstraction on top of the peripheral access
-API for the STMicro STM32F0xx family of microcontrollers. It replaces the
-[stm32f042-hal][] by a more ubiqitous version suitable for additional families.
+[_stm32f0xx-hal_](https://github.com/stm32-rs/stm32f0xx-hal) contains a hardware abstraction on top of the peripheral access API for the STMicro STM32F0xx family of microcontrollers.
 
-Currently supported configuration are:
-* stm32f030
-* stm32f030x4
-* stm32f030x6
-* stm32f030x8
-* stm32f030xc
-* stm32f042
-* stm32f070
-* stm32f070x6
-* stm32f070xb
-* stm32f072
-* stm32f091
+This crate replaces the [stm32f042-hal](https://github.com/therealprof/stm32f042-hal) by a more ubiqitous version suitable for additional families. The idea behind this crate is to gloss over the slight differences in the various peripherals available on those MCUs so a HAL can be written for all chips in that same family without having to cut and paste crates for every single model.
 
-The idea behind this crate is to gloss over the slight differences in the
-various peripherals available on those MCUs so a HAL can be written for all
-chips in that same family without having to cut and paste crates for every
-single model.
+This crate relies on Adam Greig's fantastic [stm32f0](https://crates.io/crates/stm32f0) crate to provide appropriate register definitions, and implements a partial set of the [embedded-hal](https://github.com/rust-embedded/embedded-hal) traits. Some of the implementation was shamelessly adapted from the [stm32f103xx-hal](https://github.com/japaric/stm32f103xx-hal) crate by Jorge Aparicio.
 
-Collaboration on this crate is highly welcome as are pull requests!
+Collaboration on this crate is highly welcome, as are pull requests!
 
-This crate relies on Adam Greigs fantastic [stm32f0][] crate to provide
-appropriate register definitions and implements a partial set of the
-[embedded-hal][] traits.
 
-Some of the implementation was shamelessly adapted from the [stm32f103xx-hal][]
-crate by Jorge Aparicio.
+Supported Configurations
+------------------------
 
-[stm32f0]: https://crates.io/crates/stm32f0
-[stm32f042-hal]: https://github.com/therealprof/stm32f042-hal
-[stm32f103xx-hal]: https://github.com/japaric/stm32f103xx-hal
-[embedded-hal]: https://github.com/japaric/embedded-hal.git
+* __stm32f030__ (stm32f030x4, stm32f030x6, stm32f030x8, stm32f030xc)  
+* __stm32f042__  
+* __stm32f070__ (stm32f070x6, stm32f070xb)  
+* __stm32f072__  
+* __stm32f091__  
+
+
+Getting Started
+---------------
+
+If you are unfamiliar with embedded development using Rust, there are a number of fantastic resources available to help.
+
+- [Embedded Rust Documentation](https://docs.rust-embedded.org/)  
+- [The Embedded Rust Book](https://docs.rust-embedded.org/book/)  
+- [Rust Embedded FAQ](https://docs.rust-embedded.org/faq.html)  
+- [rust-embedded/awesome-embedded-rust](https://github.com/rust-embedded/awesome-embedded-rust)
+
+
+Changelog
+---------
+
+See [CHANGELOG.md](CHANGELOG.md).
+
 
 License
 -------
 
-[0-clause BSD license](LICENSE-0BSD.txt).
+0-Clause BSD License, see [LICENSE-0BSD.txt](LICENSE-0BSD.txt) for more details.


### PR DESCRIPTION
As the title suggest, I went through and tidied up the README, added missing links, etc. As requested in #10 I also added a basic Getting Started section.

I understand this stuff is all pretty subjective, so if there are any changes that aren't sitting well with anybody just let me know and I have no problem making some modification.