### PR TITLE
Optimize delay implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Support for STM32F091 - @jessebraham
 - Support for HSE as a system clocksource (#25 - breaking change) - @zklapow
 
+### Changed
+
+- Optimize delay implemenation (#42) - @david-sawatzke
+
 ### Fixed
 
 - Fixed panic in delay overflow handling for debug builds - @david-sawatzke

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -1,7 +1,7 @@
 //! API for delays with the systick timer
 //!
-//! Please be aware of potential overflows.
-//! For example, the maximum delay with 48MHz is around 89 seconds
+//! Please be aware of potential overflows when using `delay_us`.
+//! E.g. at 48MHz the maximum delay is 89 seconds.
 //!
 //! Consider using the timers api as a more flexible interface
 //!
@@ -42,8 +42,6 @@ const SYSTICK_RANGE: u32 = 0x0100_0000;
 
 impl Delay {
     /// Configures the system timer (SysTick) as a delay provider
-    /// As access to the count register is possible without a reference, we can
-    /// just drop it
     pub fn new(mut syst: SYST, clocks: Clocks) -> Delay {
         syst.set_clock_source(SystClkSource::Core);
 
@@ -54,11 +52,14 @@ impl Delay {
         let scale = clocks.hclk().0 / 1_000_000;
 
         Delay { scale }
+        // As access to the count register is possible without a reference to the systick, we can
+        // just drop it
     }
 }
 
 impl DelayMs<u32> for Delay {
-    // At 48 MHz, calling delay_us with ms * 1_000 directly overflows at 0x15D868 (just over the max u16 value)
+    // At 48 MHz (the maximum frequency), calling delay_us with ms * 1_000 directly overflows at 0x15D86 (just over the max u16 value)
+    // So we implement a separate, higher level, delay loop
     fn delay_ms(&mut self, mut ms: u32) {
         const MAX_MS: u32 = 0x0000_FFFF;
         while ms != 0 {
@@ -71,7 +72,9 @@ impl DelayMs<u32> for Delay {
 
 impl DelayMs<u16> for Delay {
     fn delay_ms(&mut self, ms: u16) {
-        self.delay_us(u32::from(ms) * 1_000);
+        // Call delay_us directly, so we don't have to use the additional
+        // delay loop the u32 variant uses
+        self.delay_us(u32(ms) * 1_000);
     }
 }
 
@@ -81,24 +84,28 @@ impl DelayMs<u8> for Delay {
     }
 }
 
+// At 48MHz (the maximum frequency), this overflows at approx. 2^32 / 48 = 89 seconds
 impl DelayUs<u32> for Delay {
     fn delay_us(&mut self, us: u32) {
         // The SysTick Reload Value register supports values between 1 and 0x00FFFFFF.
         // Here less than maximum is used so we have some play if there's a long running interrupt.
-        const MAX_RVR: u32 = 0x007F_FFFF;
+        const MAX_TICKS: u32 = 0x007F_FFFF;
 
-        let mut total_rvr = us * self.scale;
+        let mut total_ticks = us * self.scale;
 
-        while total_rvr != 0 {
-            let current_rvr = if total_rvr <= MAX_RVR {
-                total_rvr
+        while total_ticks != 0 {
+            let current_ticks = if total_ticks <= MAX_TICKS {
+                total_ticks
             } else {
-                MAX_RVR
+                MAX_TICKS
             };
 
             let start_count = SYST::get_current();
-            total_rvr -= current_rvr;
-            while (start_count.wrapping_sub(SYST::get_current()) % SYSTICK_RANGE) < current_rvr {}
+            total_ticks -= current_ticks;
+
+            // Use the wrapping substraction and the modulo to deal with the systick wrapping around
+            // from 0 to 0xFFFF
+            while (start_count.wrapping_sub(SYST::get_current()) % SYSTICK_RANGE) < current_ticks {}
         }
     }
 }


### PR DESCRIPTION
I tried to optimize the delay implementation a bit. It gets now inlined (without division) in blinky_delay and makes led_hal_button_irq a bit smaller. Unfortunately the division is still in the delay method (here for blinky_multiple):
```

0800027c <_ZN97_$LT$stm32f0xx_hal..delay..Delay$u20$as$u20$embedded_hal..blocking..delay..DelayMs$LT$u16$GT$$GT$8delay_ms17hee9179c2bd627785E>:
 800027c:	b570      	push	{r4, r5, r6, lr}
 800027e:	2801      	cmp	r0, #1
 8000280:	d105      	bne.n	800028e <_ZN97_$LT$stm32f0xx_hal..delay..Delay$u20$as$u20$embedded_hal..blocking..delay..DelayMs$LT$u16$GT$$GT$8delay_ms17hee9179c2bd627785E+0x12>
 8000282:	2900      	cmp	r1, #0
 8000284:	d018      	beq.n	80002b8 <_ZN97_$LT$stm32f0xx_hal..delay..Delay$u20$as$u20$embedded_hal..blocking..delay..DelayMs$LT$u16$GT$$GT$8delay_ms17hee9179c2bd627785E+0x3c>
 8000286:	480e      	ldr	r0, [pc, #56]	; (80002c0 <_ZN97_$LT$stm32f0xx_hal..delay..Delay$u20$as$u20$embedded_hal..blocking..delay..DelayMs$LT$u16$GT$$GT$8delay_ms17hee9179c2bd627785E+0x44>)
 8000288:	f000 f854 	bl	8000334 <__aeabi_uidiv>
```

This is caused by the optimizer leaving the `Div` case in, for some reason.

Untested