### PR TITLE
Remove STM32F030 from devices that have I2C1 available on pins PA11 a…

### DIFF
--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -72,7 +72,7 @@ i2c_pins! {
         sda => [gpioa::PA10<Alternate<AF4>>],
     }
 }
-#[cfg(any(feature = "stm32f030", feature = "stm32f042", feature = "stm32f048"))]
+#[cfg(any(feature = "stm32f042", feature = "stm32f048"))]
 i2c_pins! {
     I2C1 => {
         scl => [gpioa::PA11<Alternate<AF5>>],


### PR DESCRIPTION
…nd PA12.