### PR TITLE
systick returns, so should be marked as such.

### DIFF
--- a/examples/adc_values.rs
+++ b/examples/adc_values.rs
@@ -70,7 +70,7 @@ fn main() -> ! {
 }
 
 #[exception]
-fn SysTick() -> ! {
+fn SysTick() {
     use core::ops::DerefMut;
 
     // Enter critical section

--- a/examples/flash_systick.rs
+++ b/examples/flash_systick.rs
@@ -57,7 +57,7 @@ fn main() -> ! {
 // Define an exception handler, i.e. function to call when exception occurs. Here, if our SysTick
 // timer generates an exception the following handler will be called
 #[exception]
-fn SysTick() -> ! {
+fn SysTick() {
     // Exception handler state variable
     static mut STATE: u8 = 1;
 

--- a/examples/flash_systick_fancier.rs
+++ b/examples/flash_systick_fancier.rs
@@ -60,7 +60,7 @@ fn main() -> ! {
 // Define an exception handler, i.e. function to call when exception occurs. Here, if our SysTick
 // timer generates an exception the following handler will be called
 #[exception]
-fn SysTick() -> ! {
+fn SysTick() {
     // Our moved LED pin
     static mut LED: Option<LEDPIN> = None;
 


### PR DESCRIPTION
systick() should return `()`. This fixes build errors that CI has been reporting.