### PR TITLE
RCC: PLL: Modify CR instead of write, plus remove unnecessary unsafe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- RCC: Correct code to enable PLL.
+
 ## [v0.15.2] - 2019-11-04
 
 ### Changed

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -87,9 +87,9 @@ mod inner {
 
         // Set PLL source and multiplier
         rcc.cfgr
-            .modify(|_, w| unsafe { w.pllsrc().bit(pllsrc_bit).pllmul().bits(pllmul_bits) });
+            .modify(|_, w| w.pllsrc().bit(pllsrc_bit).pllmul().bits(pllmul_bits));
 
-        rcc.cr.write(|w| w.pllon().set_bit());
+        rcc.cr.modify(|_, w| w.pllon().set_bit());
         while rcc.cr.read().pllrdy().bit_is_clear() {}
 
         rcc.cfgr
@@ -176,7 +176,7 @@ mod inner {
         rcc.cfgr
             .modify(|_, w| w.pllsrc().bits(pllsrc_bit).pllmul().bits(pllmul_bits));
 
-        rcc.cr.write(|w| w.pllon().set_bit());
+        rcc.cr.modify(|_, w| w.pllon().set_bit());
         while rcc.cr.read().pllrdy().bit_is_clear() {}
 
         rcc.cfgr


### PR DESCRIPTION
The PLL was not locking on a F070RB. Part of the reason was that the CR register was written instead of modified. This, plus fixed computation of the PLL multiplier (similar to #78) and #80, allows the PLL to lock.

(If I should first create an issue for this, or should combine all small changes together into one PR, let me know).