### PR TITLE
RCC: USB source switching code.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Changed
 
 - Added "bypass" parameter to Rcc HSE configuration (breaking change)
+- Add "usbsrc" function to Rcc configuration, used for selecting USB clock source
 
 ### Fixed
 - RCC: Correct code to enable PLL.


### PR DESCRIPTION
This adds an RCC API feature to set the USB clock source. This is necessary for STM32F070 and also if a crystal is desired to be used for a USB clock (instead of the RCC).

Similar to yesterday's patch, this has lots of `cfg` attributes to control which features are available for the various MCU models. It looks like we could create a new attribute macro like `cfg_has_usb` to apply the proper device list, but I'm leaning towards the simplicity of what this PRcontains.

This does not yet make USB F070 USB work (yet), as the PLL multipliers are not calculated correctly (related to #78), but it is another step in that direction. 

This should close #83.