### PR TITLE
RCC: Correct PLL multiplier calculations.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Added "bypass" parameter to Rcc HSE configuration (breaking change)
 - Add "usbsrc" function to Rcc configuration, used for selecting USB clock source
+- For STM32F030, require use more specific feature flag, e.g. "stm32f030xc"
 
 ### Fixed
 - RCC: Correct code to enable PLL.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 - RCC: Correct code to enable PLL.
+- RCC: Correct calculation of PLL multiplier.
 
 ## [v0.15.2] - 2019-11-04
 

--- a/tools/check.py
+++ b/tools/check.py
@@ -30,7 +30,7 @@ def main():
 
     features = [""] + ["{} rt".format(x)
                        for x in crate_info["features"].keys()
-                       if x != "device-selected" and x != "rt"]
+                       if x != "device-selected" and x != "rt" and x != "stm32f030"]
 
     if 'size_check' in sys.argv:
         cargo_cmd = ['cargo', 'build', '--release']


### PR DESCRIPTION
This adds logic to determine if HSI/2 is an available clock source (instead of HSI/PLLDIV), and fixes a few logic errors:

* Disable CI build if stm32f030 is specified without the more specific stm32f030
* Add RCC_PLLSRC_PREDIV1_SUPPORT constant to specify if the PLLSRC register is one or two bits. Note that this is erring on the side of the reference manual. The CMSIS headers and ST HAL show that the F070 should support PREDIV1 (and hardware does work). A source code comment has been added about this. It's possible that F030xC also has support. The stm32f0 crate would need to be modified to enable two-bit PLLSRC for these models.
* Correct PLL multiplier computation to depend on what the predivisor is set to.
* If the multiplier was 2, PLL was not being enabled. This lets it be enabled.
* hclk and flash latency calculations are based on the calculated value of sysclk, not the requested value.
* rcc.CFGR register should be modified, not written, to preserve values that were valid at reset. (minor issue, and debatable since the reset value is 0x0000_0000)

Code was verified to work with HSI and HSE, targeting 8 MHz and 16 MHz sysclk, on the STM32f070RB.

While there is not code to determine appropriate fractional dividers, this code will help with that in the future (if someone needs it for their application).

Closes #77 
