### PR TITLE
Assume twice the timer frequency when HCLK != PCLK

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,8 +17,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Fixed
 
-- RCC: Correct code to enable PLL.
-- RCC: Correct calculation of PLL multiplier.
+- Timer: Fix use of wrong frequency when HCLK != PCLK
+- RCC: Correct code to enable PLL
+- RCC: Correct calculation of PLL multiplier
 
 ## [v0.15.2] - 2019-11-04
 

--- a/src/timers.rs
+++ b/src/timers.rs
@@ -185,7 +185,13 @@ macro_rules! timers {
                     self.tim.cnt.reset();
 
                     let frequency = timeout.into().0;
-                    let ticks = self.clocks.pclk().0 / frequency;
+                    // If pclk is prescaled from hclk, the frequency fed into the timers is doubled
+                    let tclk = if self.clocks.hclk().0 == self.clocks.pclk().0 {
+                        self.clocks.pclk().0
+                    } else {
+                        self.clocks.pclk().0 * 2
+                    };
+                    let ticks = tclk / frequency;
 
                     let psc = cast::u16((ticks - 1) / (1 << 16)).unwrap();
                     self.tim.psc.write(|w| w.psc().bits(psc));


### PR DESCRIPTION
Internally the frequency going to the timers is doubled if PCLK is
prescaled.

Fixes #90

Signed-off-by: Daniel Egger <daniel@eggers-club.de>