### PR TITLE
Seal the DAC trait to prevent UB

### DIFF
--- a/src/dac.rs
+++ b/src/dac.rs
@@ -87,25 +87,29 @@ pub trait DacPin {
     fn enable(&mut self);
 }
 
-pub trait Pins<DAC> {
-    type Output;
+mod sealed {
+    // This trait is unsafe and sealed because we use MaybeUninit to
+    // return an instance of the type, and should only be used on ZSTs.
+    pub unsafe trait Pins<DAC> {
+        type Output;
+    }
 }
 
-impl Pins<DAC> for PA4<Analog> {
+unsafe impl sealed::Pins<DAC> for PA4<Analog> {
     type Output = C1;
 }
 
-impl Pins<DAC> for PA5<Analog> {
+unsafe impl sealed::Pins<DAC> for PA5<Analog> {
     type Output = C2;
 }
 
-impl Pins<DAC> for (PA4<Analog>, PA5<Analog>) {
+unsafe impl sealed::Pins<DAC> for (PA4<Analog>, PA5<Analog>) {
     type Output = (C1, C2);
 }
 
 pub fn dac<PINS>(_dac: DAC, _pins: PINS, rcc: &mut Rcc) -> PINS::Output
 where
-    PINS: Pins<DAC>,
+    PINS: sealed::Pins<DAC>,
 {
     // Enable DAC clocks
     rcc.regs.apb1enr.modify(|_, w| w.dacen().set_bit());
@@ -114,7 +118,7 @@ where
     rcc.regs.apb1rstr.modify(|_, w| w.dacrst().set_bit());
     rcc.regs.apb1rstr.modify(|_, w| w.dacrst().clear_bit());
 
-    unsafe { mem::uninitialized() }
+    unsafe { mem::MaybeUninit::uninit().assume_init() }
 }
 
 macro_rules! dac {
@@ -143,13 +147,13 @@ macro_rules! dac {
 pub trait DacExt {
     fn constrain<PINS>(self, pins: PINS, rcc: &mut Rcc) -> PINS::Output
     where
-        PINS: Pins<DAC>;
+        PINS: sealed::Pins<DAC>;
 }
 
 impl DacExt for DAC {
     fn constrain<PINS>(self, pins: PINS, rcc: &mut Rcc) -> PINS::Output
     where
-        PINS: Pins<DAC>,
+        PINS: sealed::Pins<DAC>,
     {
         dac(self, pins, rcc)
     }


### PR DESCRIPTION
Before this change, the following user code would compile and run without warnings, and would return an uninitialized `[u8; 16]`, which would be UB:

```rust
struct UB;
use crate::stm32::DAC;
impl Pins<DAC> for UB {
    type Output = [u8; 16];
}

// ...

let mut rcc = dp.RCC.configure().sysclk(8.mhz()).freeze(&mut dp.FLASH);
let gpioa = dp.GPIOA.split(&mut rcc);
let mut uninit = dac(dp.DAC, UB, &mut rcc);
```

This change seals the trait and marks it unsafe to prevent outside malicious use, as well as warn maintainers.

