### PR TITLE
Soft-deprecate `stm32` for PAC access and use `pac` instead

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Changed
+
+- Use `pac` instead of `stm32` for PAC access and soft-deprecate the former
+
 ### Added
 
 - Another example resembling a stop watch controlled via serial interface

--- a/examples/adc_values.rs
+++ b/examples/adc_values.rs
@@ -5,7 +5,7 @@ use panic_halt as _;
 
 use stm32f0xx_hal as hal;
 
-use crate::hal::{prelude::*, stm32};
+use crate::hal::{prelude::*, pac};
 
 use cortex_m::{interrupt::Mutex, peripheral::syst::SystClkSource::Core};
 use cortex_m_rt::{entry, exception};
@@ -14,7 +14,7 @@ use core::{cell::RefCell, fmt::Write};
 
 struct Shared {
     adc: hal::adc::Adc,
-    tx: hal::serial::Tx<stm32::USART1>,
+    tx: hal::serial::Tx<pac::USART1>,
 }
 
 static SHARED: Mutex<RefCell<Option<Shared>>> = Mutex::new(RefCell::new(None));
@@ -22,7 +22,7 @@ static SHARED: Mutex<RefCell<Option<Shared>>> = Mutex::new(RefCell::new(None));
 #[entry]
 fn main() -> ! {
     if let (Some(p), Some(cp)) = (
-        hal::stm32::Peripherals::take(),
+        hal::pac::Peripherals::take(),
         cortex_m::peripheral::Peripherals::take(),
     ) {
         cortex_m::interrupt::free(move |cs| {

--- a/examples/blinky.rs
+++ b/examples/blinky.rs
@@ -5,13 +5,13 @@ use panic_halt as _;
 
 use stm32f0xx_hal as hal;
 
-use crate::hal::{prelude::*, stm32};
+use crate::hal::{prelude::*, pac};
 
 use cortex_m_rt::entry;
 
 #[entry]
 fn main() -> ! {
-    if let Some(mut p) = stm32::Peripherals::take() {
+    if let Some(mut p) = pac::Peripherals::take() {
         let mut led = cortex_m::interrupt::free(|cs| {
             let mut rcc = p.RCC.configure().sysclk(8.mhz()).freeze(&mut p.FLASH);
 

--- a/examples/blinky_adc.rs
+++ b/examples/blinky_adc.rs
@@ -5,14 +5,14 @@ use panic_halt as _;
 
 use stm32f0xx_hal as hal;
 
-use crate::hal::{adc::Adc, delay::Delay, prelude::*, stm32};
+use crate::hal::{adc::Adc, delay::Delay, prelude::*, pac};
 
 use cortex_m::peripheral::Peripherals;
 use cortex_m_rt::entry;
 
 #[entry]
 fn main() -> ! {
-    if let (Some(mut p), Some(cp)) = (stm32::Peripherals::take(), Peripherals::take()) {
+    if let (Some(mut p), Some(cp)) = (pac::Peripherals::take(), Peripherals::take()) {
         cortex_m::interrupt::free(move |cs| {
             let mut rcc = p.RCC.configure().sysclk(8.mhz()).freeze(&mut p.FLASH);
 

--- a/examples/blinky_delay.rs
+++ b/examples/blinky_delay.rs
@@ -5,14 +5,14 @@ use panic_halt as _;
 
 use stm32f0xx_hal as hal;
 
-use crate::hal::{delay::Delay, prelude::*, stm32};
+use crate::hal::{delay::Delay, prelude::*, pac};
 
 use cortex_m::peripheral::Peripherals;
 use cortex_m_rt::entry;
 
 #[entry]
 fn main() -> ! {
-    if let (Some(mut p), Some(cp)) = (stm32::Peripherals::take(), Peripherals::take()) {
+    if let (Some(mut p), Some(cp)) = (pac::Peripherals::take(), Peripherals::take()) {
         cortex_m::interrupt::free(move |cs| {
             let mut rcc = p.RCC.configure().sysclk(8.mhz()).freeze(&mut p.FLASH);
 

--- a/examples/blinky_multiple.rs
+++ b/examples/blinky_multiple.rs
@@ -5,14 +5,14 @@ use panic_halt as _;
 
 use stm32f0xx_hal as hal;
 
-use crate::hal::{delay::Delay, prelude::*, stm32};
+use crate::hal::{delay::Delay, prelude::*, pac};
 
 use cortex_m::peripheral::Peripherals;
 use cortex_m_rt::entry;
 
 #[entry]
 fn main() -> ! {
-    if let (Some(mut p), Some(cp)) = (stm32::Peripherals::take(), Peripherals::take()) {
+    if let (Some(mut p), Some(cp)) = (pac::Peripherals::take(), Peripherals::take()) {
         cortex_m::interrupt::free(move |cs| {
             let mut rcc = p.RCC.configure().sysclk(8.mhz()).freeze(&mut p.FLASH);
 

--- a/examples/blinky_timer.rs
+++ b/examples/blinky_timer.rs
@@ -5,13 +5,13 @@ use panic_halt as _;
 
 use stm32f0xx_hal as hal;
 
-use crate::hal::{prelude::*, stm32, time::Hertz, timers::*};
+use crate::hal::{prelude::*, pac, time::Hertz, timers::*};
 
 use cortex_m_rt::entry;
 
 #[entry]
 fn main() -> ! {
-    if let Some(mut p) = stm32::Peripherals::take() {
+    if let Some(mut p) = pac::Peripherals::take() {
         cortex_m::interrupt::free(move |cs| {
             let mut rcc = p.RCC.configure().sysclk(8.mhz()).freeze(&mut p.FLASH);
 

--- a/examples/blinky_timer_irq.rs
+++ b/examples/blinky_timer_irq.rs
@@ -7,8 +7,8 @@ use stm32f0xx_hal as hal;
 
 use crate::hal::{
     gpio::*,
+    pac::{interrupt, Interrupt, Peripherals, TIM7},
     prelude::*,
-    stm32::{interrupt, Interrupt, Peripherals, TIM7},
     time::Hertz,
     timers::*,
 };

--- a/examples/dac.rs
+++ b/examples/dac.rs
@@ -9,8 +9,8 @@ use panic_halt as _;
 use stm32f0xx_hal as hal;
 
 use crate::hal::dac::*;
+use crate::hal::pac;
 use crate::hal::prelude::*;
-use crate::hal::stm32;
 
 use rt::entry;
 
@@ -21,7 +21,7 @@ enum Direction {
 
 #[entry]
 fn main() -> ! {
-    if let (Some(mut dp), Some(_cp)) = (stm32::Peripherals::take(), cortex_m::Peripherals::take()) {
+    if let (Some(mut dp), Some(_cp)) = (pac::Peripherals::take(), cortex_m::Peripherals::take()) {
         cortex_m::interrupt::free(move |cs| {
             let mut rcc = dp.RCC.configure().sysclk(8.mhz()).freeze(&mut dp.FLASH);
 

--- a/examples/flash_systick.rs
+++ b/examples/flash_systick.rs
@@ -5,7 +5,7 @@ use panic_halt as _;
 
 use stm32f0xx_hal as hal;
 
-use crate::hal::{gpio::*, prelude::*, stm32};
+use crate::hal::{gpio::*, prelude::*, pac};
 
 use cortex_m::{interrupt::Mutex, peripheral::syst::SystClkSource::Core, Peripherals};
 use cortex_m_rt::{entry, exception};
@@ -18,7 +18,7 @@ static GPIO: Mutex<RefCell<Option<gpioa::PA1<Output<PushPull>>>>> = Mutex::new(R
 
 #[entry]
 fn main() -> ! {
-    if let (Some(mut p), Some(cp)) = (stm32::Peripherals::take(), Peripherals::take()) {
+    if let (Some(mut p), Some(cp)) = (pac::Peripherals::take(), Peripherals::take()) {
         cortex_m::interrupt::free(move |cs| {
             let mut rcc = p.RCC.configure().sysclk(48.mhz()).freeze(&mut p.FLASH);
 

--- a/examples/flash_systick_fancier.rs
+++ b/examples/flash_systick_fancier.rs
@@ -5,7 +5,7 @@ use panic_halt as _;
 
 use stm32f0xx_hal as hal;
 
-use crate::hal::{gpio::*, prelude::*, stm32};
+use crate::hal::{gpio::*, prelude::*, pac};
 
 use cortex_m::{interrupt::Mutex, peripheral::syst::SystClkSource::Core, Peripherals};
 use cortex_m_rt::{entry, exception};
@@ -21,7 +21,7 @@ static GPIO: Mutex<RefCell<Option<LEDPIN>>> = Mutex::new(RefCell::new(None));
 
 #[entry]
 fn main() -> ! {
-    if let (Some(mut p), Some(cp)) = (stm32::Peripherals::take(), Peripherals::take()) {
+    if let (Some(mut p), Some(cp)) = (pac::Peripherals::take(), Peripherals::take()) {
         cortex_m::interrupt::free(move |cs| {
             let mut rcc = p.RCC.configure().sysclk(48.mhz()).freeze(&mut p.FLASH);
 

--- a/examples/i2c_find_address.rs
+++ b/examples/i2c_find_address.rs
@@ -5,7 +5,7 @@ use panic_halt as _;
 
 use stm32f0xx_hal as hal;
 
-use crate::hal::{i2c::I2c, prelude::*, stm32};
+use crate::hal::{i2c::I2c, prelude::*, pac};
 
 use cortex_m_rt::entry;
 
@@ -13,7 +13,7 @@ use cortex_m_rt::entry;
 
 #[entry]
 fn main() -> ! {
-    if let Some(p) = stm32::Peripherals::take() {
+    if let Some(p) = pac::Peripherals::take() {
         cortex_m::interrupt::free(move |cs| {
             let mut flash = p.FLASH;
             let mut rcc = p.RCC.configure().freeze(&mut flash);

--- a/examples/led_hal_button_irq.rs
+++ b/examples/led_hal_button_irq.rs
@@ -8,8 +8,8 @@ use stm32f0xx_hal as hal;
 use crate::hal::{
     delay::Delay,
     gpio::*,
+    pac::{interrupt, Interrupt, Peripherals, EXTI},
     prelude::*,
-    stm32::{interrupt, Interrupt, Peripherals, EXTI},
 };
 
 use cortex_m::{interrupt::Mutex, peripheral::Peripherals as c_m_Peripherals};

--- a/examples/serial_echo.rs
+++ b/examples/serial_echo.rs
@@ -5,13 +5,13 @@ use panic_halt as _;
 
 use stm32f0xx_hal as hal;
 
-use crate::hal::{prelude::*, serial::Serial, stm32};
+use crate::hal::{prelude::*, serial::Serial, pac};
 
 use cortex_m_rt::entry;
 
 #[entry]
 fn main() -> ! {
-    if let Some(p) = stm32::Peripherals::take() {
+    if let Some(p) = pac::Peripherals::take() {
         cortex_m::interrupt::free(move |cs| {
             let mut flash = p.FLASH;
             let mut rcc = p.RCC.configure().sysclk(48.mhz()).freeze(&mut flash);

--- a/examples/serial_spi_bridge.rs
+++ b/examples/serial_spi_bridge.rs
@@ -10,7 +10,7 @@ use crate::hal::{
     serial::Serial,
     spi::Spi,
     spi::{Mode, Phase, Polarity},
-    stm32,
+    pac,
 };
 
 use nb::block;
@@ -30,7 +30,7 @@ fn main() -> ! {
         phase: Phase::CaptureOnSecondTransition,
     };
 
-    if let Some(p) = stm32::Peripherals::take() {
+    if let Some(p) = pac::Peripherals::take() {
         cortex_m::interrupt::free(move |cs| {
             let mut flash = p.FLASH;
             let mut rcc = p.RCC.configure().freeze(&mut flash);

--- a/examples/serial_stopwatch.rs
+++ b/examples/serial_stopwatch.rs
@@ -6,9 +6,9 @@ use panic_halt as _;
 use stm32f0xx_hal as hal;
 
 use crate::hal::{
+    pac::{interrupt, Interrupt, Peripherals, TIM7},
     prelude::*,
     serial::Serial,
-    stm32::{interrupt, Interrupt, Peripherals, TIM7},
     timers::{Event, Timer},
 };
 use core::cell::RefCell;

--- a/examples/spi_hal_apa102c.rs
+++ b/examples/spi_hal_apa102c.rs
@@ -9,7 +9,7 @@ use crate::hal::{
     prelude::*,
     spi::Spi,
     spi::{Mode, Phase, Polarity},
-    stm32,
+    pac,
 };
 
 use cortex_m_rt::entry;
@@ -21,7 +21,7 @@ fn main() -> ! {
         phase: Phase::CaptureOnSecondTransition,
     };
 
-    if let Some(p) = stm32::Peripherals::take() {
+    if let Some(p) = pac::Peripherals::take() {
         cortex_m::interrupt::free(move |cs| {
             let mut flash = p.FLASH;
             let mut rcc = p.RCC.configure().freeze(&mut flash);

--- a/examples/usb_serial.rs
+++ b/examples/usb_serial.rs
@@ -7,13 +7,13 @@ extern crate panic_halt;
 
 use cortex_m_rt::entry;
 use stm32f0xx_hal::usb::{Peripheral, UsbBus};
-use stm32f0xx_hal::{prelude::*, stm32};
+use stm32f0xx_hal::{prelude::*, pac};
 use usb_device::prelude::*;
 use usbd_serial::{SerialPort, USB_CLASS_CDC};
 
 #[entry]
 fn main() -> ! {
-    let mut dp = stm32::Peripherals::take().unwrap();
+    let mut dp = pac::Peripherals::take().unwrap();
 
     /* Uncomment the following lines if you have a chip in TSSOP20 (STM32F042F)
        or UFQFPN28 (STM32F042G) package

--- a/examples/watchdog.rs
+++ b/examples/watchdog.rs
@@ -6,7 +6,7 @@ use panic_halt as _;
 use stm32f0xx_hal as hal;
 
 use crate::hal::{
-    delay::Delay, prelude::*, serial::Serial, stm32, time::Hertz, watchdog::Watchdog,
+    delay::Delay, prelude::*, serial::Serial, pac, time::Hertz, watchdog::Watchdog,
 };
 
 use cortex_m::peripheral::Peripherals;
@@ -16,7 +16,7 @@ use core::fmt::Write;
 
 #[entry]
 fn main() -> ! {
-    if let (Some(p), Some(cp)) = (stm32::Peripherals::take(), Peripherals::take()) {
+    if let (Some(p), Some(cp)) = (pac::Peripherals::take(), Peripherals::take()) {
         cortex_m::interrupt::free(move |cs| {
             let mut flash = p.FLASH;
             let mut rcc = p.RCC.configure().sysclk(8.mhz()).freeze(&mut flash);

--- a/src/adc.rs
+++ b/src/adc.rs
@@ -8,12 +8,12 @@
 //! ``` no_run
 //! use stm32f0xx_hal as hal;
 //!
-//! use crate::hal::stm32;
+//! use crate::hal::pac;
 //! use crate::hal::prelude::*;
 //! use crate::hal::adc::Adc;
 //!
 //! cortex_m::interrupt::free(|cs| {
-//!     let mut p = stm32::Peripherals::take().unwrap();
+//!     let mut p = pac::Peripherals::take().unwrap();
 //!     let mut rcc = p.RCC.configure().freeze(&mut p.FLASH);
 //!
 //!     let gpioa = p.GPIOA.split(&mut rcc);
@@ -52,14 +52,14 @@ use embedded_hal::{
 use crate::{
     delay::Delay,
     gpio::*,
-    rcc::Rcc,
-    stm32::{
+    pac::{
         adc::{
             cfgr1::{ALIGN_A, RES_A},
             smpr::SMP_A,
         },
         ADC,
     },
+    rcc::Rcc,
 };
 
 /// Analog to Digital converter interface

--- a/src/dac.rs
+++ b/src/dac.rs
@@ -15,7 +15,7 @@
 //!
 //!use stm32f0xx_hal as hal;
 //!
-//!use crate::hal::stm32;
+//!use crate::hal::pac;
 //!use crate::hal::prelude::*;
 //!use crate::hal::dac::*;
 //!
@@ -28,7 +28,7 @@
 //!
 //!#[entry]
 //!fn main() -> ! {
-//!    if let (Some(mut dp), Some(_cp)) = (stm32::Peripherals::take(), cortex_m::Peripherals::take()) {
+//!    if let (Some(mut dp), Some(_cp)) = (pac::Peripherals::take(), cortex_m::Peripherals::take()) {
 //!        cortex_m::interrupt::free(move |cs| {
 //!            let mut rcc = dp.RCC.configure().sysclk(8.mhz()).freeze(&mut dp.FLASH);
 //!
@@ -72,8 +72,8 @@ use core::mem;
 
 use crate::gpio::gpioa::{PA4, PA5};
 use crate::gpio::Analog;
+use crate::pac::DAC;
 use crate::rcc::Rcc;
-use crate::stm32::DAC;
 
 pub struct C1;
 pub struct C2;

--- a/src/delay.rs
+++ b/src/delay.rs
@@ -10,12 +10,12 @@
 //! ``` no_run
 //! use stm32f0xx_hal as hal;
 //!
-//! use crate::hal::stm32;
+//! use crate::hal::pac;
 //! use crate::hal::prelude::*;
 //! use crate::hal::delay::Delay;
 //! use cortex_m::peripheral::Peripherals;
 //!
-//! let mut p = stm32::Peripherals::take().unwrap();
+//! let mut p = pac::Peripherals::take().unwrap();
 //! let mut cp = cortex_m::Peripherals::take().unwrap();
 //!
 //! let mut rcc = p.RCC.configure().freeze(&mut p.FLASH);

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -144,7 +144,7 @@ impl<MODE> InputPin for Pin<Input<MODE>> {
 
 macro_rules! gpio_trait {
     ($gpiox:ident) => {
-        impl GpioRegExt for crate::stm32::$gpiox::RegisterBlock {
+        impl GpioRegExt for crate::pac::$gpiox::RegisterBlock {
             fn is_low(&self, pos: u8) -> bool {
                 // NOTE(unsafe) atomic read with no side effects
                 self.idr.read().bits() & (1 << pos) == 0
@@ -185,7 +185,7 @@ macro_rules! gpio {
                 use embedded_hal::digital::v2::{InputPin, OutputPin, StatefulOutputPin, toggleable};
                 use crate::{
                     rcc::Rcc,
-                    stm32::$GPIOX
+                    pac::$GPIOX
                 };
 
                 use cortex_m::interrupt::CriticalSection;

--- a/src/i2c.rs
+++ b/src/i2c.rs
@@ -1,6 +1,6 @@
 use core::ops::Deref;
 
-use embedded_hal::blocking::i2c::{Write, WriteRead, Read};
+use embedded_hal::blocking::i2c::{Read, Write, WriteRead};
 
 use crate::{
     gpio::*,
@@ -24,10 +24,10 @@ macro_rules! i2c_pins {
     })+) => {
         $(
             $(
-                impl SclPin<crate::stm32::$I2C> for $scl {}
+                impl SclPin<crate::pac::$I2C> for $scl {}
             )+
             $(
-                impl SdaPin<crate::stm32::$I2C> for $sda {}
+                impl SdaPin<crate::pac::$I2C> for $sda {}
             )+
         )+
     }
@@ -154,7 +154,7 @@ pub enum Error {
 macro_rules! i2c {
     ($($I2C:ident: ($i2c:ident, $i2cXen:ident, $i2cXrst:ident, $apbenr:ident, $apbrstr:ident),)+) => {
         $(
-            use crate::stm32::$I2C;
+            use crate::pac::$I2C;
             impl<SCLPIN, SDAPIN> I2c<$I2C, SCLPIN, SDAPIN> {
                 pub fn $i2c(i2c: $I2C, pins: (SCLPIN, SDAPIN), speed: KiloHertz, rcc: &mut Rcc) -> Self
                 where
@@ -196,7 +196,7 @@ i2c! {
 
 // It's s needed for the impls, but rustc doesn't recognize that
 #[allow(dead_code)]
-type I2cRegisterBlock = crate::stm32::i2c1::RegisterBlock;
+type I2cRegisterBlock = crate::pac::i2c1::RegisterBlock;
 
 impl<I2C, SCLPIN, SDAPIN> I2c<I2C, SCLPIN, SDAPIN>
 where
@@ -257,7 +257,7 @@ where
         (self.i2c, self.pins)
     }
 
-    fn check_and_clear_error_flags(&self, isr: &crate::stm32::i2c1::isr::R) -> Result<(), Error> {
+    fn check_and_clear_error_flags(&self, isr: &crate::pac::i2c1::isr::R) -> Result<(), Error> {
         // If we received a NACK, then this is an error
         if isr.nackf().bit_is_set() {
             self.i2c

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,7 +4,7 @@
 pub use stm32f0;
 
 #[cfg(any(feature = "stm32f030", feature = "stm32f070"))]
-pub use stm32f0::stm32f0x0 as stm32;
+pub use stm32f0::stm32f0x0 as pac;
 
 #[cfg(any(
     feature = "stm32f031",
@@ -12,10 +12,10 @@ pub use stm32f0::stm32f0x0 as stm32;
     feature = "stm32f071",
     feature = "stm32f091",
 ))]
-pub use stm32f0::stm32f0x1 as stm32;
+pub use stm32f0::stm32f0x1 as pac;
 
 #[cfg(any(feature = "stm32f042", feature = "stm32f072"))]
-pub use stm32f0::stm32f0x2 as stm32;
+pub use stm32f0::stm32f0x2 as pac;
 
 #[cfg(any(
     feature = "stm32f038",
@@ -24,7 +24,7 @@ pub use stm32f0::stm32f0x2 as stm32;
     feature = "stm32f078",
     feature = "stm32f098",
 ))]
-pub use stm32f0::stm32f0x8 as stm32;
+pub use stm32f0::stm32f0x8 as pac;
 
 #[cfg(feature = "device-selected")]
 pub mod adc;
@@ -83,3 +83,7 @@ pub mod tsc;
 pub mod usb;
 #[cfg(feature = "device-selected")]
 pub mod watchdog;
+
+#[cfg(feature = "device-selected")]
+#[deprecated(since = "0.17.0", note = "please use `pac` instead")]
+pub use pac as stm32;

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -1,4 +1,4 @@
-use crate::stm32::RCC;
+use crate::pac::RCC;
 use crate::time::Hertz;
 
 /// Extension trait that sets up the `RCC` peripheral
@@ -71,7 +71,7 @@ pub enum USBClockSource {
 /// RCC for F0x0 devices
 #[cfg(any(feature = "stm32f030", feature = "stm32f070",))]
 mod inner {
-    use crate::stm32::{rcc::cfgr::SW_A, RCC};
+    use crate::pac::{rcc::cfgr::SW_A, RCC};
 
     pub(super) const HSI: u32 = 8_000_000; // Hz
 
@@ -172,7 +172,7 @@ mod inner {
     feature = "stm32f098",
 ))]
 mod inner {
-    use crate::stm32::{rcc::cfgr::SW_A, RCC};
+    use crate::pac::{rcc::cfgr::SW_A, RCC};
 
     pub(super) const HSI: u32 = 8_000_000; // Hz
     #[cfg(any(
@@ -354,7 +354,7 @@ pub struct CFGR {
         feature = "stm32f091",
         feature = "stm32f098",
     ))]
-    crs: Option<crate::stm32::CRS>,
+    crs: Option<crate::pac::CRS>,
     rcc: RCC,
 }
 
@@ -426,12 +426,12 @@ impl CFGR {
         feature = "stm32f091",
         feature = "stm32f098",
     ))]
-    pub fn enable_crs(mut self, crs: crate::stm32::CRS) -> Self {
+    pub fn enable_crs(mut self, crs: crate::pac::CRS) -> Self {
         self.crs = Some(crs);
         self
     }
 
-    pub fn freeze(mut self, flash: &mut crate::stm32::FLASH) -> Rcc {
+    pub fn freeze(mut self, flash: &mut crate::pac::FLASH) -> Rcc {
         // Default to lowest frequency clock on all systems.
         let sysclk = self.sysclk.unwrap_or(self::inner::HSI);
 

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -12,7 +12,7 @@
 //!
 //! use crate::hal::prelude::*;
 //! use crate::hal::serial::Serial;
-//! use crate::hal::stm32;
+//! use crate::hal::pac;
 //!
 //! use nb::block;
 //!
@@ -39,7 +39,7 @@
 //!
 //! use crate::hal::prelude::*;
 //! use crate::hal::serial::Serial;
-//! use crate::hal::stm32;
+//! use crate::hal::pac;
 //!
 //! use nb::block;
 //!
@@ -104,10 +104,10 @@ macro_rules! usart_pins {
     })+) => {
         $(
             $(
-                impl TxPin<crate::stm32::$USART> for $tx {}
+                impl TxPin<crate::pac::$USART> for $tx {}
             )+
             $(
-                impl RxPin<crate::stm32::$USART> for $rx {}
+                impl RxPin<crate::pac::$USART> for $rx {}
             )+
         )+
     }
@@ -263,7 +263,7 @@ pub struct Serial<USART, TXPIN, RXPIN> {
 }
 
 // Common register
-type SerialRegisterBlock = crate::stm32::usart1::RegisterBlock;
+type SerialRegisterBlock = crate::pac::usart1::RegisterBlock;
 
 /// Serial receiver
 pub struct Rx<USART> {
@@ -286,7 +286,7 @@ unsafe impl<USART> Send for Tx<USART> {}
 macro_rules! usart {
     ($($USART:ident: ($usart:ident, $usarttx:ident, $usartrx:ident, $usartXen:ident, $apbenr:ident),)+) => {
         $(
-            use crate::stm32::$USART;
+            use crate::pac::$USART;
             impl<TXPIN, RXPIN> Serial<$USART, TXPIN, RXPIN>
             where
                 TXPIN: TxPin<$USART>,

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -9,12 +9,12 @@
 //! ``` no_run
 //! use stm32f0xx_hal as hal;
 //!
-//! use crate::hal::stm32;
+//! use crate::hal::pac;
 //! use crate::hal::prelude::*;
 //! use crate::hal::spi::{Spi, Mode, Phase, Polarity};
 //!
 //! cortex_m::interrupt::free(|cs| {
-//!     let mut p = stm32::Peripherals::take().unwrap();
+//!     let mut p = pac::Peripherals::take().unwrap();
 //!     let mut rcc = p.RCC.constrain().freeze(&mut p.FLASH);
 //!
 //!     let gpioa = p.GPIOA.split(&mut rcc);
@@ -45,7 +45,7 @@ pub use embedded_hal::spi::{Mode, Phase, Polarity};
 
 // TODO Put this inside the macro
 // Currently that causes a compiler panic
-use crate::stm32::SPI1;
+use crate::pac::SPI1;
 #[cfg(any(
     feature = "stm32f030x8",
     feature = "stm32f030xc",
@@ -60,7 +60,7 @@ use crate::stm32::SPI1;
     feature = "stm32f091",
     feature = "stm32f098",
 ))]
-use crate::stm32::SPI2;
+use crate::pac::SPI2;
 
 use crate::gpio::*;
 
@@ -99,13 +99,13 @@ macro_rules! spi_pins {
     })+) => {
         $(
             $(
-                impl SckPin<crate::stm32::$SPI> for $sck {}
+                impl SckPin<crate::pac::$SPI> for $sck {}
             )+
             $(
-                impl MisoPin<crate::stm32::$SPI> for $miso {}
+                impl MisoPin<crate::pac::$SPI> for $miso {}
             )+
             $(
-                impl MosiPin<crate::stm32::$SPI> for $mosi {}
+                impl MosiPin<crate::pac::$SPI> for $mosi {}
             )+
         )+
     }
@@ -256,7 +256,7 @@ spi! {
 
 // It's s needed for the impls, but rustc doesn't recognize that
 #[allow(dead_code)]
-type SpiRegisterBlock = crate::stm32::spi1::RegisterBlock;
+type SpiRegisterBlock = crate::pac::spi1::RegisterBlock;
 
 impl<SPI, SCKPIN, MISOPIN, MOSIPIN> Spi<SPI, SCKPIN, MISOPIN, MOSIPIN>
 where

--- a/src/timers.rs
+++ b/src/timers.rs
@@ -7,14 +7,14 @@
 //! ``` no_run
 //! use stm32f0xx_hal as hal;
 //!
-//! use crate::hal::stm32;
+//! use crate::hal::pac;
 //! use crate::hal::prelude::*;
 //! use crate::hal::time::*;
 //! use crate::hal::timers::*;
 //! use nb::block;
 //!
 //! cortex_m::interrupt::free(|cs| {
-//!     let mut p = stm32::Peripherals::take().unwrap();
+//!     let mut p = pac::Peripherals::take().unwrap();
 //!     let mut rcc = p.RCC.configure().freeze(&mut p.FLASH);
 //!
 //!     let gpioa = p.GPIOA.split(&mut rcc);
@@ -116,7 +116,7 @@ impl Periodic for Timer<SYST> {}
 macro_rules! timers {
     ($($TIM:ident: ($tim:ident, $timXen:ident, $timXrst:ident, $apbenr:ident, $apbrstr:ident),)+) => {
         $(
-            use crate::stm32::$TIM;
+            use crate::pac::$TIM;
             impl Timer<$TIM> {
                 // XXX(why not name this `new`?) bummer: constructors need to have different names
                 // even if the `$TIM` are non overlapping (compare to the `free` function below
@@ -162,7 +162,7 @@ macro_rules! timers {
 
                 /// Releases the TIM peripheral
                 pub fn release(self) -> $TIM {
-                    let rcc = unsafe { &(*crate::stm32::RCC::ptr()) };
+                    let rcc = unsafe { &(*crate::pac::RCC::ptr()) };
                     // Pause counter
                     self.tim.cr1.modify(|_, w| w.cen().clear_bit());
                     // Disable timer

--- a/src/tsc.rs
+++ b/src/tsc.rs
@@ -8,8 +8,8 @@
 //! electrode fitting a human finger tip size across a few millimeters dielectric panel.
 
 use crate::gpio::{gpioa, gpiob, Alternate, AF3};
+use crate::pac::TSC;
 use crate::rcc::Rcc;
-use crate::stm32::TSC;
 
 #[derive(Debug)]
 pub enum Event {

--- a/src/usb.rs
+++ b/src/usb.rs
@@ -5,7 +5,7 @@
 //! See <https://github.com/stm32-rs/stm32f0xx-hal/tree/master/examples>
 //! for usage examples.
 
-use crate::stm32::{RCC, USB};
+use crate::pac::{RCC, USB};
 use stm32_usbd::UsbPeripheral;
 
 use crate::gpio::gpioa::{PA11, PA12};

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -28,12 +28,12 @@
 //! ``` no_run
 //! use stm32f0xx_hal as hal;
 //!
-//! use crate::hal::stm32;
+//! use crate::hal::pac;
 //! use crate::hal::prelude::*;
 //! use crate::hal:watchdog::Watchdog;
 //! use crate::hal:time::Hertz;
 //!
-//! let mut p = stm32::Peripherals::take().unwrap();
+//! let mut p = pac::Peripherals::take().unwrap();
 //!
 //! let mut iwdg = Watchdog::new(p.iwdg);
 //! iwdg.start(Hertz(100));
@@ -43,7 +43,7 @@
 //! ```
 use embedded_hal::watchdog;
 
-use crate::stm32::IWDG;
+use crate::pac::IWDG;
 use crate::time::Hertz;
 
 /// Watchdog instance


### PR DESCRIPTION
Signed-off-by: Daniel Egger <daniel@eggers-club.de>