### PR TITLE
Simplify serial `read()` error handling

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Changed
 
+- Remove duplicate error bits clearing in serial `read()` implementation
 - Optimize SPI implementation
 - Use `pac` instead of `stm32` for PAC access and soft-deprecate the former
 - Updated stm32f0 dependency to v0.10 (breaking change)


### PR DESCRIPTION
Clearing the error bits once should suffice

Signed-off-by: Daniel Egger <daniel@eggers-club.de>