### PR TITLE
bxcan-based CAN interface

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-- Add CAN bus abstraction.
+- Add CAN bus abstraction based on the [bxcan] crate.
+
+[bxcan]: https://crates.io/crates/bxcan
 
 ## [v0.17.1] - 2020-08-30
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ stm32f0 = "0.12.1"
 nb = "1.0"
 void = { version = "1.0", default-features = false }
 stm32-usbd = { version = "0.5.1", features = ["ram_access_2x16"], optional = true }
-bxcan = "0.2.0"
+bxcan = "0.4.0"
 
 [dev-dependencies]
 cortex-m-rt = "0.6"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,6 +38,7 @@ stm32f0 = "0.12.1"
 nb = "1.0"
 void = { version = "1.0", default-features = false }
 stm32-usbd = { version = "0.5.1", features = ["ram_access_2x16"], optional = true }
+bxcan = "0.2.0"
 
 [dev-dependencies]
 cortex-m-rt = "0.6"

--- a/src/can.rs
+++ b/src/can.rs
@@ -1,12 +1,21 @@
-use super::pac;
-use super::pac::can::TX;
+use bxcan::{FilterOwner, Instance, RegisterBlock};
+
 use crate::gpio::gpioa::{PA11, PA12};
 use crate::gpio::gpiob::{PB8, PB9};
 use crate::gpio::{Alternate, AF4};
+use crate::pac::CAN;
 use crate::rcc::Rcc;
 
-pub trait RxPin {}
-pub trait TxPin {}
+mod sealed {
+    pub trait Sealed {}
+}
+
+use self::sealed::Sealed;
+
+pub use bxcan;
+
+pub trait RxPin: Sealed {}
+pub trait TxPin: Sealed {}
 
 macro_rules! can_pins {
     (
@@ -14,9 +23,11 @@ macro_rules! can_pins {
         tx => [$($tx:ty),+ $(,)*],
     ) => {
         $(
+            impl Sealed for $rx {}
             impl RxPin for $rx {}
         )+
         $(
+            impl Sealed for $tx {}
             impl TxPin for $tx {}
         )+
     };
@@ -28,198 +39,48 @@ can_pins! {
     tx => [PA12<Alternate<AF4>>, PB9<Alternate<AF4>>],
 }
 
-pub struct CANBus<RX_PIN, TX_PIN> {
-    can: pac::CAN,
-    _rx: RX_PIN,
-    _tx: TX_PIN,
+#[cfg(any(feature = "stm32f072", feature = "stm32f091"))]
+use crate::gpio::{
+    gpiod::{PD0, PD1},
+    AF0,
+};
+
+#[cfg(any(feature = "stm32f072", feature = "stm32f091"))]
+can_pins! {
+    rx => [PD0<Alternate<AF0>>],
+    tx => [PD1<Alternate<AF0>>],
 }
 
-pub enum Event {
-    RxMessagePending,
+/// Resources used by the CAN peripheral.
+pub struct CanInstance<T: TxPin, R: RxPin> {
+    peripheral: CAN,
+    tx: T,
+    rx: R,
 }
 
-impl<RX_PIN, TX_PIN> CANBus<RX_PIN, TX_PIN>
-where
-    RX_PIN: RxPin,
-    TX_PIN: TxPin,
-{
-    pub fn new(can: pac::CAN, rx: RX_PIN, tx: TX_PIN, rcc: &mut Rcc) -> Self {
+impl<T: TxPin, R: RxPin> CanInstance<T, R> {
+    pub fn new(peripheral: CAN, tx: T, rx: R, rcc: &mut Rcc) -> Self {
         rcc.regs.apb1enr.modify(|_, w| w.canen().enabled());
         rcc.regs.apb1rstr.modify(|_, w| w.canrst().reset());
         rcc.regs.apb1rstr.modify(|_, w| w.canrst().clear_bit());
 
-        can.mcr.write(|w| w.sleep().clear_bit());
-        can.mcr.modify(|_, w| w.inrq().set_bit());
-        while !can.msr.read().inak().bit() {}
-
-        can.mcr.modify(|_, w| {
-            w.ttcm()
-                .clear_bit() // no time triggered communication
-                .abom()
-                .set_bit() // bus automatically recovers itself after error state
-                .awum()
-                .set_bit() // bus is automatically waken up on message RX
-                .nart()
-                .clear_bit() // automatic message retransmission enabled
-                .rflm()
-                .clear_bit() // new RX message overwrite unread older ones
-                .txfp()
-                .clear_bit() // TX message priority driven by the message identifier
-                .sleep()
-                .clear_bit() // do not sleep
-        });
-        // calculated using http://www.bittiming.can-wiki.info/ for STMicroelectronics bxCAN 48 MHz clock, 87.6% sample point, SJW = 1, bitrate 250 kHz
-        const TIME_SEGMENT1: u8 = 13;
-        const TIME_SEGMENT2: u8 = 2;
-        const RESYNC_WIDTH: u8 = 1;
-        const PRESCALER: u16 = 12;
-        can.btr.modify(|_, w| unsafe {
-            w.silm()
-                .clear_bit() // disable silent mode
-                .lbkm()
-                .clear_bit() // disable loopback mode
-                .sjw()
-                .bits(RESYNC_WIDTH - 1)
-                .ts2()
-                .bits(TIME_SEGMENT2 - 1)
-                .ts1()
-                .bits(TIME_SEGMENT1 - 1)
-                .brp()
-                .bits(PRESCALER - 1)
-        });
-
-        can.mcr.modify(|_, w| w.inrq().clear_bit());
-        while !can.msr.read().inak().bit() {}
-
-        can.fmr.modify(|_, w| w.finit().set_bit()); // filter init enabled
-        can.fa1r.write(|w| w.fact0().clear_bit()); // filter is inactive
-
-        can.fm1r.write(|w| w.fbm0().clear_bit()); // identifier mask mode for fbm0
-        can.fs1r.write(|w| w.fsc0().set_bit()); // 32 bit scale configuration
-
-        // const FILTER0_ID: u16 = 0x0;
-        // const FILTER0_MASK: u16 = 0x00;
-        // const FILTER1_ID: u16 = 0x00;
-        // const FILTER1_MASK: u16 = 0x00;
-        can.fb[0].fr1.write(|w| unsafe { w.bits(0) });
-        can.fb[0].fr2.write(|w| unsafe { w.bits(0) });
-
-        can.fa1r.write(|w| w.fact0().set_bit()); // filter is active
-        can.fmr.modify(|_, w| w.finit().clear_bit()); // filter init disabled
-
-        Self {
-            can,
-            _rx: rx,
-            _tx: tx,
-        }
+        Self { peripheral, tx, rx }
     }
 
-    pub fn write(&self, frame: &CANFrame) -> nb::Result<(), CANError> {
-        if self.can.tsr.read().tme0().bit_is_set() {
-            self.write_to_mailbox(&self.can.tx[0], frame);
-            Ok(())
-        } else if self.can.tsr.read().tme1().bit_is_set() {
-            self.write_to_mailbox(&self.can.tx[1], frame);
-            Ok(())
-        } else if self.can.tsr.read().tme2().bit_is_set() {
-            self.write_to_mailbox(&self.can.tx[2], frame);
-            Ok(())
-        } else {
-            Err(nb::Error::WouldBlock)
-        }
+    pub fn into_raw(self) -> (CAN, T, R) {
+        (self.peripheral, self.tx, self.rx)
     }
 
-    fn write_to_mailbox(&self, tx: &TX, frame: &CANFrame) {
-        tx.tdtr.write(|w| unsafe { w.dlc().bits(frame.dlc) });
-        tx.tdlr.write(|w| unsafe {
-            w.data0()
-                .bits(frame.data[0])
-                .data1()
-                .bits(frame.data[1])
-                .data2()
-                .bits(frame.data[2])
-                .data3()
-                .bits(frame.data[3])
-        });
-        tx.tdhr.write(|w| unsafe {
-            w.data4()
-                .bits(frame.data[4])
-                .data5()
-                .bits(frame.data[5])
-                .data6()
-                .bits(frame.data[6])
-                .data7()
-                .bits(frame.data[7])
-        });
-
-        tx.tir.write(|w| unsafe {
-            w.stid()
-                .bits(frame.id)
-                .ide()
-                .standard()
-                .rtr()
-                .bit(frame.rtr)
-                .txrq()
-                .set_bit()
-        });
-    }
-
-    pub fn read(&self) -> nb::Result<CANFrame, CANError> {
-        for (i, rfr) in self.can.rfr.iter().enumerate() {
-            let pending = rfr.read().fmp().bits();
-            if pending > 0 {
-                let rx = &self.can.rx[i];
-                let id = rx.rir.read().stid().bits();
-                let rtr = rx.rir.read().rtr().bit_is_set();
-                let dlc = rx.rdtr.read().dlc().bits();
-
-                let data0 = rx.rdlr.read().data0().bits();
-                let data1 = rx.rdlr.read().data1().bits();
-                let data2 = rx.rdlr.read().data2().bits();
-                let data3 = rx.rdlr.read().data3().bits();
-                let data4 = rx.rdhr.read().data4().bits();
-                let data5 = rx.rdhr.read().data5().bits();
-                let data6 = rx.rdhr.read().data6().bits();
-                let data7 = rx.rdhr.read().data7().bits();
-
-                rfr.modify(|_, w| w.rfom().release()); // release
-                if rfr.read().fovr().bit_is_set() {
-                    rfr.modify(|_, w| w.fovr().clear());
-                }
-
-                if rfr.read().full().bit_is_set() {
-                    rfr.modify(|_, w| w.full().clear());
-                }
-
-                let frame = CANFrame {
-                    id,
-                    rtr,
-                    dlc,
-                    data: [data0, data1, data2, data3, data4, data5, data6, data7],
-                };
-                return Ok(frame);
-            }
-        }
-        Err(nb::Error::WouldBlock)
-    }
-
-    pub fn listen(&self, event: Event) {
-        match event {
-            Event::RxMessagePending => {
-                self.can
-                    .ier
-                    .modify(|_, w| w.fmpie0().set_bit().fmpie1().set_bit());
-            }
-        }
+    /// Returns a reference to the raw CAN peripheral.
+    pub unsafe fn peripheral(&mut self) -> &mut CAN {
+        &mut self.peripheral
     }
 }
 
-pub enum CANError {}
+unsafe impl<T: TxPin, R: RxPin> Instance for CanInstance<T, R> {
+    const REGISTERS: *mut RegisterBlock = CAN::ptr() as *mut _;
+}
 
-#[derive(Copy, Clone, Default)]
-pub struct CANFrame {
-    pub id: u16,
-    pub rtr: bool,
-    pub dlc: u8,
-    pub data: [u8; 8],
+unsafe impl<T: TxPin, R: RxPin> FilterOwner for CanInstance<T, R> {
+    const NUM_FILTER_BANKS: u8 = 14;
 }


### PR DESCRIPTION
This changes the CAN API to use the [bxcan](https://github.com/jonas-schievink/bxcan) crate, a reusable driver for the bxCAN peripherals in many low- to middle-end STM32 MCUs.