### PR TITLE
Poll for completion on SPI write.

### DIFF
--- a/src/spi.rs
+++ b/src/spi.rs
@@ -400,7 +400,7 @@ where
             nb::Error::Other(Error::ModeFault)
         } else if sr.crcerr().bit_is_set() {
             nb::Error::Other(Error::Crc)
-        } else if sr.txe().bit_is_set() {
+        } else if sr.txe().bit_is_set() && sr.bsy().bit_is_clear() {
             return Ok(());
         } else {
             nb::Error::WouldBlock
@@ -481,15 +481,8 @@ where
             bufcap -= 1;
         }
 
-        loop {
-            let sr = self.spi.sr.read();
-            if !sr.bsy().bit_is_set() {
-                break;
-            }
-        }
-
         // Do one last status register check before continuing
-        self.check_send().ok();
+        nb::block!(self.check_send()).ok();
         Ok(())
     }
 }
@@ -532,15 +525,8 @@ where
             self.send_u16(word.clone());
         }
 
-        loop {
-            let sr = self.spi.sr.read();
-            if !sr.bsy().bit_is_set() {
-                break;
-            }
-        }
-
         // Do one last status register check before continuing
-        self.check_send().ok();
+        nb::block!(self.check_send()).ok();
         Ok(())
     }
 }

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -481,6 +481,13 @@ where
             bufcap -= 1;
         }
 
+        loop {
+            let sr = self.spi.sr.read();
+            if !sr.bsy().bit_is_set() {
+                break;
+            }
+        }
+
         // Do one last status register check before continuing
         self.check_send().ok();
         Ok(())
@@ -523,6 +530,13 @@ where
         for word in words {
             nb::block!(self.check_send())?;
             self.send_u16(word.clone());
+        }
+
+        loop {
+            let sr = self.spi.sr.read();
+            if !sr.bsy().bit_is_set() {
+                break;
+            }
         }
 
         // Do one last status register check before continuing


### PR DESCRIPTION
Closes #130

---

Continuing discussion from #130 :

The suggested implementation was replacing this:
```rust
 self.check_send().ok(); 
 Ok(()) 
 ```
 
 With this:
 ```rust
 nb::block!(self.check_send())
 ```
 
The concern I have with that is it seems the last `check_send().ok()` was intended to clear the `OVR` error bit that may be set due to dropped reads.

Additionally, it does not seem that this works as intended, the CS still goes high before the write is completed with consecutive write calls.



