### PR TITLE
Update bxcan to 0.5.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ stm32f0 = "0.13"
 nb = "1"
 void = { version = "1.0", default-features = false }
 stm32-usbd = { version = "0.6", optional = true }
-bxcan = "0.4.0"
+bxcan = "0.5.0"
 
 [dev-dependencies]
 cortex-m-rt = "0.6"


### PR DESCRIPTION
[bxcan 0.5.0](https://github.com/stm32-rs/bxcan/blob/master/CHANGELOG.md) updates the defmt dependency to 0.2.0.
