### PR TITLE
fix new clippy lints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Add CAN bus abstraction based on the [bxcan] crate.
 - Add PWM output generation based on the timers.
+- Added `impl From<KiloHertz> for Hertz`
+- Added `impl From<MegaHertz> for Hertz`
+- Added `impl From<KiloHertz> for MegaHertz`
+- Added `impl From<Hertz> for IwdgTimeout`
 
 [bxcan]: https://crates.io/crates/bxcan
 

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -58,6 +58,7 @@ pub enum HSEBypassMode {
     feature = "stm32f072",
     feature = "stm32f078",
 ))]
+#[allow(clippy::upper_case_acronyms)]
 pub enum USBClockSource {
     #[cfg(feature = "stm32f070")]
     /// USB peripheral's tranceiver is disabled
@@ -89,6 +90,7 @@ mod inner {
     ))]
     pub(super) const RCC_PLLSRC_PREDIV1_SUPPORT: bool = false;
 
+    #[allow(clippy::upper_case_acronyms)]
     pub(super) enum SysClkSource {
         HSI,
         /// High-speed external clock(freq,bypassed)
@@ -205,6 +207,7 @@ mod inner {
     ))]
     pub(super) const RCC_PLLSRC_PREDIV1_SUPPORT: bool = false;
 
+    #[allow(clippy::upper_case_acronyms)]
     pub(super) enum SysClkSource {
         HSI,
         /// High-speed external clock(freq,bypassed)

--- a/src/time.rs
+++ b/src/time.rs
@@ -44,20 +44,20 @@ impl U32Ext for u32 {
     }
 }
 
-impl Into<Hertz> for KiloHertz {
-    fn into(self) -> Hertz {
-        Hertz(self.0 * 1_000)
+impl From<KiloHertz> for Hertz {
+    fn from(khz: KiloHertz) -> Self {
+        Hertz(khz.0 * 1_000)
     }
 }
 
-impl Into<Hertz> for MegaHertz {
-    fn into(self) -> Hertz {
-        Hertz(self.0 * 1_000_000)
+impl From<MegaHertz> for Hertz {
+    fn from(mhz: MegaHertz) -> Self {
+        Hertz(mhz.0 * 1_000_000)
     }
 }
 
-impl Into<KiloHertz> for MegaHertz {
-    fn into(self) -> KiloHertz {
-        KiloHertz(self.0 * 1_000)
+impl From<MegaHertz> for KiloHertz {
+    fn from(mhz: MegaHertz) -> Self {
+        KiloHertz(mhz.0 * 1_000)
     }
 }

--- a/src/watchdog.rs
+++ b/src/watchdog.rs
@@ -66,13 +66,13 @@ pub struct IwdgTimeout {
     reload: u16,
 }
 
-impl Into<IwdgTimeout> for Hertz {
+impl From<Hertz> for IwdgTimeout {
     /// This converts the value so it's usable by the IWDG
     /// Due to conversion losses, the specified frequency is a maximum
     ///
     /// It can also only represent values < 10000 Hertz
-    fn into(self) -> IwdgTimeout {
-        let mut time = 40_000 / 4 / self.0;
+    fn from(hz: Hertz) -> Self {
+        let mut time = 40_000 / 4 / hz.0;
         let mut psc = 0;
         let mut reload = 0;
         while psc < 7 {


### PR DESCRIPTION
This resolves these 6 clippy failures:

```text
warning: name `HSI` contains a capitalized acronym
  --> src/rcc.rs:93:9
   |
93 |         HSI,
   |         ^^^ help: consider making the acronym lowercase, except the initial letter (notice the capitalization): `Hsi`
   |
   = note: `#[warn(clippy::upper_case_acronyms)]` on by default
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms

warning: name `HSE` contains a capitalized acronym
  --> src/rcc.rs:95:9
   |
95 |         HSE(u32, super::HSEBypassMode),
   |         ^^^ help: consider making the acronym lowercase, except the initial letter: `Hse`
   |
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#upper_case_acronyms

warning: an implementation of `From` is preferred since it gives you `Into<_>` for free where the reverse isn't true
  --> src/time.rs:47:1
   |
47 | impl Into<Hertz> for KiloHertz {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = note: `#[warn(clippy::from_over_into)]` on by default
   = help: consider to implement `From<time::KiloHertz>` instead
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#from_over_into

warning: an implementation of `From` is preferred since it gives you `Into<_>` for free where the reverse isn't true
  --> src/time.rs:53:1
   |
53 | impl Into<Hertz> for MegaHertz {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: consider to implement `From<time::MegaHertz>` instead
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#from_over_into

warning: an implementation of `From` is preferred since it gives you `Into<_>` for free where the reverse isn't true
  --> src/time.rs:59:1
   |
59 | impl Into<KiloHertz> for MegaHertz {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: consider to implement `From<time::MegaHertz>` instead
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#from_over_into

warning: an implementation of `From` is preferred since it gives you `Into<_>` for free where the reverse isn't true
  --> src/watchdog.rs:69:1
   |
69 | impl Into<IwdgTimeout> for Hertz {
   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
   |
   = help: consider to implement `From<time::Hertz>` instead
   = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#from_over_into

warning: `stm32f0xx-hal` (lib) generated 6 warnings
```