### PR TITLE
Set mode correctly on C2 of 2-channel PWM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- Wrong mode when using PWM channel 2 of a two-channel timer
+
 ## [v0.18.0] - 2021-11-14
 
 ### Changed

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -321,7 +321,7 @@ macro_rules! pwm_2_channels {
                     tim.ccmr1_output().modify(|_, w| w.oc1pe().set_bit().oc1m().bits(6));
                 }
                 if PINS::C2 {
-                    tim.ccmr1_output().modify(|_, w| w.oc2pe().set_bit().oc1m().bits(6));
+                    tim.ccmr1_output().modify(|_, w| w.oc2pe().set_bit().oc2m().bits(6));
                 }
 
                 // If pclk is prescaled from hclk, the frequency fed into the timers is doubled


### PR DESCRIPTION
When configuring a 2-channel PWM and setting up channel 2 mode, we accidentally set up channel 1 mode instead.

I haven't actually verified the currently broken behaviour on hardware since I'm using 4-channel PWM where this configuration is done correctly, but this one looks like a simple copy-paste error which I spotted while studying the code :sweat_smile: