### PR TITLE
Provide access to serial status flags idle/txe/rxne

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Updated the `cast` dependency from 0.2 to 0.3
 
+### Added
+
+- Provide getters to serial status flags idle/txe/rxne/tc.
+
 ### Fixed
 
 - Wrong mode when using PWM channel 2 of a two-channel timer

--- a/src/serial.rs
+++ b/src/serial.rs
@@ -378,6 +378,26 @@ macro_rules! usart {
                         },
                     }
                 }
+
+                /// Returns true if the line idle status is set
+                pub fn is_idle(&self) -> bool {
+                    self.usart.isr.read().idle().bit_is_set()
+                }
+
+                /// Returns true if the tx register is empty
+                pub fn is_txe(&self) -> bool {
+                    self.usart.isr.read().txe().bit_is_set()
+                }
+
+                /// Returns true if the rx register is not empty (and can be read)
+                pub fn is_rx_not_empty(&self) -> bool {
+                    self.usart.isr.read().rxne().bit_is_set()
+                }
+
+                /// Returns true if transmission is complete
+                pub fn is_tx_complete(&self) -> bool {
+                    self.usart.isr.read().tc().bit_is_set()
+                }
             }
         )+
     }


### PR DESCRIPTION
Noticed that the serial interface were missing access to these flags and seem to be present in other stm32xx hals (like stm32f4xx-hal).

Added them so that an ISR can differ between these events.

Edit: removed unnecessary unsafe.