### PR TITLE
Provide ability to clear timer UIF interrup flag

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - Provide getters to serial status flags idle/txe/rxne/tc.
+- Provide ability to reset timer UIF interrupt flag
 
 ### Fixed
 

--- a/src/timers.rs
+++ b/src/timers.rs
@@ -168,6 +168,11 @@ macro_rules! timers {
                     rcc.$apbenr.modify(|_, w| w.$timXen().clear_bit());
                     self.tim
                 }
+
+                /// Clears interrupt flag
+                pub fn clear_irq(&mut self) {
+                    self.tim.sr.modify(|_, w| w.uif().clear_bit());
+                }
             }
 
             impl CountDown for Timer<$TIM> {


### PR DESCRIPTION
Timer interrupts cannot be used without this method.