### PR TITLE
Add Basic Complementary Channel Support to PWM

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,8 +9,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
-- PWM complementary output capability for TIM1
-- New example to demonstrate
+- PWM complementary output capability for TIM1 with new example to demonstrate
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- PWM complementary output capability for TIM1
+- New example to demonstrate
+
 ### Changed
 
 - Updated the `cast` dependency from 0.2 to 0.3

--- a/examples/pwm_complementary.rs
+++ b/examples/pwm_complementary.rs
@@ -5,13 +5,12 @@
 // Halt on panic
 use panic_halt as _;
 
-use cortex_m_rt::entry;
 use cortex_m;
+use cortex_m_rt::entry;
 
 use stm32f0xx_hal as hal;
 
 use hal::{delay::Delay, pac, prelude::*, pwm};
-
 
 #[entry]
 fn main() -> ! {
@@ -23,7 +22,7 @@ fn main() -> ! {
         let channels = cortex_m::interrupt::free(move |cs| {
             (
                 gpioa.pa8.into_alternate_af2(cs), // on TIM1_CH1
-                gpioa.pa7.into_alternate_af2(cs),  // on TIM1_CH1N
+                gpioa.pa7.into_alternate_af2(cs), // on TIM1_CH1N
             )
         });
 
@@ -58,5 +57,4 @@ fn main() -> ! {
     loop {
         cortex_m::asm::nop();
     }
-    
 }

--- a/examples/pwm_complementary.rs
+++ b/examples/pwm_complementary.rs
@@ -1,0 +1,60 @@
+#![deny(unsafe_code)]
+#![no_main]
+#![no_std]
+
+// Halt on panic
+use panic_halt as _;
+
+use cortex_m_rt::entry;
+
+use stm32f0xx_hal as hal;
+
+use hal::{pac, prelude::*, pwm, delay::Delay};
+use cortex_m;
+
+#[entry]
+fn main() -> ! {
+    if let Some(mut dp) = pac::Peripherals::take() {
+        // Set up the system clock.
+        let mut rcc = dp.RCC.configure().sysclk(8.mhz()).freeze(&mut dp.FLASH);
+
+        let gpioa = dp.GPIOA.split(&mut rcc);
+        let channels = cortex_m::interrupt::free(move |cs| {
+            (
+                gpioa.pa8.into_alternate_af2(cs), // on TIM1_CH1
+                gpioa.pa7.into_alternate_af2(cs)  // on TIM1_CH1N
+            )
+        });
+
+        let pwm = pwm::tim1(dp.TIM1, channels, &mut rcc, 20u32.khz());
+        let (mut ch1, mut ch1n) = pwm;
+        let max_duty = ch1.get_max_duty();
+        ch1.set_duty(max_duty / 2);
+        ch1.enable();
+        ch1n.enable();
+
+        // simple duty sweep
+        if let Some(cp) = cortex_m::Peripherals::take() {
+            let mut delay = Delay::new(cp.SYST, &rcc);
+
+            let steps = 100;
+
+            loop {
+                for i in 0..steps {
+                    ch1.set_duty(max_duty / steps * i);
+                    delay.delay_ms(30u16);
+                }
+
+                for i in (1..steps).rev() {
+                    ch1.set_duty(max_duty / steps * i);
+                    delay.delay_ms(30u16);
+                }
+            }
+        }
+    }
+
+    // something went wrong when acquiring peripheral access
+    loop {
+        cortex_m::asm::nop();
+    }
+}

--- a/examples/pwm_complementary.rs
+++ b/examples/pwm_complementary.rs
@@ -6,11 +6,12 @@
 use panic_halt as _;
 
 use cortex_m_rt::entry;
+use cortex_m;
 
 use stm32f0xx_hal as hal;
 
-use hal::{pac, prelude::*, pwm, delay::Delay};
-use cortex_m;
+use hal::{delay::Delay, pac, prelude::*, pwm};
+
 
 #[entry]
 fn main() -> ! {
@@ -22,7 +23,7 @@ fn main() -> ! {
         let channels = cortex_m::interrupt::free(move |cs| {
             (
                 gpioa.pa8.into_alternate_af2(cs), // on TIM1_CH1
-                gpioa.pa7.into_alternate_af2(cs)  // on TIM1_CH1N
+                gpioa.pa7.into_alternate_af2(cs),  // on TIM1_CH1N
             )
         });
 
@@ -57,4 +58,5 @@ fn main() -> ! {
     loop {
         cortex_m::asm::nop();
     }
+    
 }

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -54,6 +54,7 @@ macro_rules! pins_impl {
 
 pins_impl!(
     (P1, P2, P3, P4), (PinC1, PinC2, PinC3, PinC4), (C1, C2, C3, C4);
+    (P1, P1N, P2, P2N, P3, P3N), (PinC1, PinC1N, PinC2, PinC2N, PinC3, PinC3N), (C1, C1N, C2, C2N, C3, C3N);
     (P1, P1N, P2, P2N), (PinC1, PinC1N, PinC2, PinC2N), (C1, C1N, C2, C2N);
     (P2, P2N, P3, P3N), (PinC2, PinC2N, PinC3, PinC3N), (C2, C2N, C3, C3N);
     (P1, P1N, P3, P3N), (PinC1, PinC1N, PinC3, PinC3N), (C1, C1N, C3, C3N);

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -8,19 +8,28 @@ use embedded_hal as hal;
 
 pub trait Pins<TIM, P> {
     const C1: bool = false;
+    const C1N: bool = false;
     const C2: bool = false;
+    const C2N: bool = false;
     const C3: bool = false;
+    const C3N: bool = false;
     const C4: bool = false;
     type Channels;
 }
 use crate::timers::PinC1;
+use crate::timers::PinC1N;
 use crate::timers::PinC2;
+use crate::timers::PinC2N;
 use crate::timers::PinC3;
+use crate::timers::PinC3N;
 use crate::timers::PinC4;
 
 pub struct C1;
+pub struct C1N;
 pub struct C2;
+pub struct C2N;
 pub struct C3;
+pub struct C3N;
 pub struct C4;
 
 pub struct PwmChannels<TIM, CHANNELS> {
@@ -45,6 +54,9 @@ macro_rules! pins_impl {
 
 pins_impl!(
     (P1, P2, P3, P4), (PinC1, PinC2, PinC3, PinC4), (C1, C2, C3, C4);
+    (P1, P1N, P2, P2N), (PinC1, PinC1N, PinC2, PinC2N), (C1, C1N, C2, C2N);
+    (P2, P2N, P3, P3N), (PinC2, PinC2N, PinC3, PinC3N), (C2, C2N, C3, C3N);
+    (P1, P1N, P3, P3N), (PinC1, PinC1N, PinC3, PinC3N), (C1, C1N, C3, C3N);
     (P2, P3, P4), (PinC2, PinC3, PinC4), (C2, C3, C4);
     (P1, P3, P4), (PinC1, PinC3, PinC4), (C1, C3, C4);
     (P1, P2, P4), (PinC1, PinC2, PinC4), (C1, C2, C4);
@@ -55,6 +67,9 @@ pins_impl!(
     (P1, P4), (PinC1, PinC4), (C1, C4);
     (P1, P3), (PinC1, PinC3), (C1, C3);
     (P1, P2), (PinC1, PinC2), (C1, C2);
+    (P1, P1N), (PinC1, PinC1N), (C1, C1N);
+    (P2, P2N), (PinC2, PinC2N), (C2, C2N);
+    (P3, P3N), (PinC3, PinC3N), (C3, C3N);
     (P1), (PinC1), (C1);
     (P2), (PinC2), (C2);
     (P3), (PinC3), (C3);
@@ -241,6 +256,282 @@ macro_rules! pwm_4_channels {
                 //NOTE(unsafe) atomic write with no side effects
                 fn enable(&mut self) {
                     unsafe { (*($TIMX::ptr())).ccer.modify(|_, w| w.cc3e().set_bit()) };
+                }
+
+                //NOTE(unsafe) atomic read with no side effects
+                fn get_duty(&self) -> u16 {
+                    unsafe { (*$TIMX::ptr()).ccr3.read().ccr().bits() as u16 }
+                }
+
+                //NOTE(unsafe) atomic read with no side effects
+                fn get_max_duty(&self) -> u16 {
+                    unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16 }
+                }
+
+                //NOTE(unsafe) atomic write with no side effects
+                fn set_duty(&mut self, duty: u16) {
+                    unsafe { (*$TIMX::ptr()).ccr3.write(|w| w.ccr().bits(duty.into())) }
+                }
+            }
+
+            impl hal::PwmPin for PwmChannels<$TIMX, C4> {
+                type Duty = u16;
+
+                //NOTE(unsafe) atomic write with no side effects
+                fn disable(&mut self) {
+                    unsafe { (*($TIMX::ptr())).ccer.modify(|_, w| w.cc4e().clear_bit()) };
+                }
+
+                //NOTE(unsafe) atomic write with no side effects
+                fn enable(&mut self) {
+                    unsafe { (*($TIMX::ptr())).ccer.modify(|_, w| w.cc4e().set_bit()) };
+                }
+
+                //NOTE(unsafe) atomic read with no side effects
+                fn get_duty(&self) -> u16 {
+                    unsafe { (*$TIMX::ptr()).ccr4.read().ccr().bits() as u16 }
+                }
+
+                //NOTE(unsafe) atomic read with no side effects
+                fn get_max_duty(&self) -> u16 {
+                    unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16 }
+                }
+
+                //NOTE(unsafe) atomic write with no side effects
+                fn set_duty(&mut self, duty: u16) {
+                    unsafe { (*$TIMX::ptr()).ccr4.write(|w| w.ccr().bits(duty.into())) }
+                }
+            }
+        )+
+    };
+}
+
+// Timer with four output channels three with complements 16 Bit Timer
+macro_rules! pwm_4_channels_with_3_complementary_outputs {
+    ($($TIMX:ident: ($timX:ident, $timXen:ident, $timXrst:ident, $apbenr:ident, $apbrstr:ident),)+) => {
+        $(
+            pub fn $timX<P, PINS, T>(tim: $TIMX, _pins: PINS, rcc: &mut Rcc, freq: T) -> PINS::Channels
+            where
+                PINS: Pins<$TIMX, P>,
+                T: Into<Hertz>,
+            {
+                // enable and reset peripheral to a clean slate state
+                rcc.regs.$apbenr.modify(|_, w| w.$timXen().set_bit());
+                rcc.regs.$apbrstr.modify(|_, w| w.$timXrst().set_bit());
+                rcc.regs.$apbrstr.modify(|_, w| w.$timXrst().clear_bit());
+
+                if PINS::C1N | PINS::C1N | PINS::C1N {
+                    tim.bdtr.modify(|_, w| w.ossr().set_bit());
+                }
+                if PINS::C1 {
+                    tim.ccmr1_output()
+                        .modify(|_, w| w.oc1pe().set_bit().oc1m().pwm_mode1() );
+                }
+                if PINS::C2 {
+                    tim.ccmr1_output()
+                        .modify(|_, w| w.oc2pe().set_bit().oc2m().pwm_mode1() );
+                }
+                if PINS::C3 {
+                    tim.ccmr2_output()
+                        .modify(|_, w| w.oc3pe().set_bit().oc3m().pwm_mode1() );
+                }
+                if PINS::C4 {
+                    tim.ccmr2_output()
+                        .modify(|_, w| w.oc4pe().set_bit().oc4m().pwm_mode1() );
+                }
+
+                // If pclk is prescaled from hclk, the frequency fed into the timers is doubled
+                let tclk = if rcc.clocks.hclk().0 == rcc.clocks.pclk().0 {
+                    rcc.clocks.pclk().0
+                } else {
+                    rcc.clocks.pclk().0 * 2
+                };
+                let ticks = tclk / freq.into().0;
+
+                let psc = u16((ticks - 1) / (1 << 16)).unwrap();
+                tim.psc.write(|w| w.psc().bits(psc) );
+                let arr = u16(ticks / u32(psc + 1)).unwrap();
+                tim.arr.write(|w| unsafe { w.bits(u32(arr)) });
+
+                // enable auto-reload preload
+                tim.cr1.modify(|_, w| w.arpe().set_bit());
+
+                // Trigger update event to load the registers
+                tim.cr1.modify(|_, w| w.urs().set_bit());
+                tim.egr.write(|w| w.ug().set_bit());
+                tim.cr1.modify(|_, w| w.urs().clear_bit());
+
+                brk!($TIMX, tim);
+                tim.cr1.write(|w|
+                    w.cms()
+                        .bits(0b00)
+                        .dir()
+                        .clear_bit()
+                        .opm()
+                        .clear_bit()
+                        .cen()
+                        .set_bit()
+                );
+                //NOTE(unsafe) `PINS::Channels` is a ZST
+                unsafe { MaybeUninit::uninit().assume_init() }
+            }
+
+            impl hal::PwmPin for PwmChannels<$TIMX, C1> {
+                type Duty = u16;
+
+                //NOTE(unsafe) atomic write with no side effects
+                fn disable(&mut self) {
+                    unsafe { (*($TIMX::ptr())).ccer.modify(|_, w| w.cc1e().clear_bit()) };
+                }
+
+                //NOTE(unsafe) atomic write with no side effects
+                fn enable(&mut self) {
+                    unsafe { (*($TIMX::ptr())).ccer.modify(|_, w| w.cc1e().set_bit()) };
+                }
+
+                //NOTE(unsafe) atomic read with no side effects
+                fn get_duty(&self) -> u16 {
+                    unsafe { (*$TIMX::ptr()).ccr1.read().ccr().bits() as u16 }
+                }
+
+                //NOTE(unsafe) atomic read with no side effects
+                fn get_max_duty(&self) -> u16 {
+                    unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16 }
+                }
+
+                //NOTE(unsafe) atomic write with no side effects
+                fn set_duty(&mut self, duty: u16) {
+                    unsafe { (*$TIMX::ptr()).ccr1.write(|w| w.ccr().bits(duty.into())) }
+                }
+            }
+
+            impl hal::PwmPin for PwmChannels<$TIMX, C1N> {
+                type Duty = u16;
+
+                //NOTE(unsafe) atomic write with no side effects
+                fn disable(&mut self) {
+                    unsafe { (*($TIMX::ptr())).ccer.modify(|_, w| w.cc1ne().clear_bit()) };
+                }
+
+                //NOTE(unsafe) atomic write with no side effects
+                fn enable(&mut self) {
+                    unsafe { (*($TIMX::ptr())).ccer.modify(|_, w| w.cc1ne().set_bit()) };
+                }
+
+                //NOTE(unsafe) atomic read with no side effects
+                fn get_duty(&self) -> u16 {
+                    unsafe { (*$TIMX::ptr()).ccr1.read().ccr().bits() as u16 }
+                }
+
+                //NOTE(unsafe) atomic read with no side effects
+                fn get_max_duty(&self) -> u16 {
+                    unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16 }
+                }
+
+                //NOTE(unsafe) atomic write with no side effects
+                fn set_duty(&mut self, duty: u16) {
+                    unsafe { (*$TIMX::ptr()).ccr1.write(|w| w.ccr().bits(duty.into())) }
+                }
+            }
+
+            impl hal::PwmPin for PwmChannels<$TIMX, C2> {
+                type Duty = u16;
+
+                //NOTE(unsafe) atomic write with no side effects
+                fn disable(&mut self) {
+                    unsafe { (*($TIMX::ptr())).ccer.modify(|_, w| w.cc2e().clear_bit()) };
+                }
+
+                //NOTE(unsafe) atomic write with no side effects
+                fn enable(&mut self) {
+                    unsafe { (*($TIMX::ptr())).ccer.modify(|_, w| w.cc2e().set_bit()) };
+                }
+
+                //NOTE(unsafe) atomic read with no side effects
+                fn get_duty(&self) -> u16 {
+                    unsafe { (*$TIMX::ptr()).ccr2.read().ccr().bits() as u16 }
+                }
+
+                //NOTE(unsafe) atomic read with no side effects
+                fn get_max_duty(&self) -> u16 {
+                    unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16 }
+                }
+
+                //NOTE(unsafe) atomic write with no side effects
+                fn set_duty(&mut self, duty: u16) {
+                    unsafe { (*$TIMX::ptr()).ccr2.write(|w| w.ccr().bits(duty.into())) }
+                }
+            }
+
+            impl hal::PwmPin for PwmChannels<$TIMX, C2N> {
+                type Duty = u16;
+
+                //NOTE(unsafe) atomic write with no side effects
+                fn disable(&mut self) {
+                    unsafe { (*($TIMX::ptr())).ccer.modify(|_, w| w.cc2ne().clear_bit()) };
+                }
+
+                //NOTE(unsafe) atomic write with no side effects
+                fn enable(&mut self) {
+                    unsafe { (*($TIMX::ptr())).ccer.modify(|_, w| w.cc2ne().set_bit()) };
+                }
+
+                //NOTE(unsafe) atomic read with no side effects
+                fn get_duty(&self) -> u16 {
+                    unsafe { (*$TIMX::ptr()).ccr2.read().ccr().bits() as u16 }
+                }
+
+                //NOTE(unsafe) atomic read with no side effects
+                fn get_max_duty(&self) -> u16 {
+                    unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16 }
+                }
+
+                //NOTE(unsafe) atomic write with no side effects
+                fn set_duty(&mut self, duty: u16) {
+                    unsafe { (*$TIMX::ptr()).ccr2.write(|w| w.ccr().bits(duty.into())) }
+                }
+            }
+
+            impl hal::PwmPin for PwmChannels<$TIMX, C3> {
+                type Duty = u16;
+
+                //NOTE(unsafe) atomic write with no side effects
+                fn disable(&mut self) {
+                    unsafe { (*($TIMX::ptr())).ccer.modify(|_, w| w.cc3e().clear_bit()) };
+                }
+
+                //NOTE(unsafe) atomic write with no side effects
+                fn enable(&mut self) {
+                    unsafe { (*($TIMX::ptr())).ccer.modify(|_, w| w.cc3e().set_bit()) };
+                }
+
+                //NOTE(unsafe) atomic read with no side effects
+                fn get_duty(&self) -> u16 {
+                    unsafe { (*$TIMX::ptr()).ccr3.read().ccr().bits() as u16 }
+                }
+
+                //NOTE(unsafe) atomic read with no side effects
+                fn get_max_duty(&self) -> u16 {
+                    unsafe { (*$TIMX::ptr()).arr.read().arr().bits() as u16 }
+                }
+
+                //NOTE(unsafe) atomic write with no side effects
+                fn set_duty(&mut self, duty: u16) {
+                    unsafe { (*$TIMX::ptr()).ccr3.write(|w| w.ccr().bits(duty.into())) }
+                }
+            }
+
+            impl hal::PwmPin for PwmChannels<$TIMX, C3N> {
+                type Duty = u16;
+
+                //NOTE(unsafe) atomic write with no side effects
+                fn disable(&mut self) {
+                    unsafe { (*($TIMX::ptr())).ccer.modify(|_, w| w.cc3ne().clear_bit()) };
+                }
+
+                //NOTE(unsafe) atomic write with no side effects
+                fn enable(&mut self) {
+                    unsafe { (*($TIMX::ptr())).ccer.modify(|_, w| w.cc3ne().set_bit()) };
                 }
 
                 //NOTE(unsafe) atomic read with no side effects
@@ -583,10 +874,12 @@ macro_rules! pwm_1_channel_with_complementary_outputs {
 use crate::pac::*;
 
 pwm_4_channels!(
-    TIM1: (tim1, tim1en, tim1rst, apb2enr, apb2rstr),
     TIM3: (tim3, tim3en, tim3rst, apb1enr, apb1rstr),
 );
 
+pwm_4_channels_with_3_complementary_outputs!(
+    TIM1: (tim1, tim1en, tim1rst, apb2enr, apb2rstr),
+);
 pwm_1_channel!(TIM14: (tim14, tim14en, tim14rst, apb1enr, apb1rstr),);
 
 pwm_1_channel_with_complementary_outputs!(

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -874,13 +874,9 @@ macro_rules! pwm_1_channel_with_complementary_outputs {
 
 use crate::pac::*;
 
-pwm_4_channels!(
-    TIM3: (tim3, tim3en, tim3rst, apb1enr, apb1rstr),
-);
+pwm_4_channels!(TIM3: (tim3, tim3en, tim3rst, apb1enr, apb1rstr),);
 
-pwm_4_channels_with_3_complementary_outputs!(
-    TIM1: (tim1, tim1en, tim1rst, apb2enr, apb2rstr),
-);
+pwm_4_channels_with_3_complementary_outputs!(TIM1: (tim1, tim1en, tim1rst, apb2enr, apb2rstr),);
 pwm_1_channel!(TIM14: (tim14, tim14en, tim14rst, apb1enr, apb1rstr),);
 
 pwm_1_channel_with_complementary_outputs!(

--- a/src/timers.rs
+++ b/src/timers.rs
@@ -285,8 +285,11 @@ use crate::gpio::{gpioa::*, gpiob::*, Alternate};
 
 // Output channels marker traits
 pub trait PinC1<TIM> {}
+pub trait PinC1N<TIM> {}
 pub trait PinC2<TIM> {}
+pub trait PinC2N<TIM> {}
 pub trait PinC3<TIM> {}
+pub trait PinC3N<TIM> {}
 pub trait PinC4<TIM> {}
 
 macro_rules! channel_impl {
@@ -299,8 +302,14 @@ macro_rules! channel_impl {
 
 channel_impl!(
     TIM1, PinC1, PA8, Alternate<AF2>;
+    TIM1, PinC1N, PA7, Alternate<AF2>;
+    TIM1, PinC1N, PB13, Alternate<AF2>;
     TIM1, PinC2, PA9, Alternate<AF2>;
+    TIM1, PinC2N, PB0, Alternate<AF2>;
+    TIM1, PinC2N, PB14, Alternate<AF2>;
     TIM1, PinC3, PA10, Alternate<AF2>;
+    TIM1, PinC3N, PB1, Alternate<AF2>;
+    TIM1, PinC3N, PB15, Alternate<AF2>;
     TIM1, PinC4, PA11, Alternate<AF2>;
 
     TIM3, PinC1, PA6, Alternate<AF1>;


### PR DESCRIPTION
## Motivation
Issue #162 created by *myself*.
TL;DR: PWM module did not support complementary channels, it should.

## Change(s) Description
- Add CHxN pins, (traits?), and structs and whatnot
- Set `OSSR` and `CCxNE` registers accordingly

## Testing
I have only confirmed it works on CH1/CH1N, but I don't see why it wouldn't work on the others.

## Warning
This is my first time using Rust.