### PR TITLE
Add support for using TIM2 as a PWM output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- PWM capability for TIM2
+
+### Added
+
 - PWM complementary output capability for TIM1 with new example to demonstrate
 
 ### Changed

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -874,7 +874,26 @@ macro_rules! pwm_1_channel_with_complementary_outputs {
 
 use crate::pac::*;
 
-pwm_4_channels!(TIM3: (tim3, tim3en, tim3rst, apb1enr, apb1rstr),);
+pwm_4_channels!(
+    TIM3: (tim3, tim3en, tim3rst, apb1enr, apb1rstr),
+);
+
+#[cfg(any(
+    feature = "stm32f031",
+    feature = "stm32f038",
+    feature = "stm32f042",
+    feature = "stm32f048",
+    feature = "stm32f051",
+    feature = "stm32f058",
+    feature = "stm32f071",
+    feature = "stm32f072",
+    feature = "stm32f078",
+    feature = "stm32f091",
+    feature = "stm32f098",
+))]
+pwm_4_channels!(
+    TIM2: (tim2, tim2en, tim2rst, apb1enr, apb1rstr),
+);
 
 pwm_4_channels_with_3_complementary_outputs!(TIM1: (tim1, tim1en, tim1rst, apb2enr, apb2rstr),);
 pwm_1_channel!(TIM14: (tim14, tim14en, tim14rst, apb1enr, apb1rstr),);

--- a/src/timers.rs
+++ b/src/timers.rs
@@ -333,6 +333,31 @@ channel_impl!(
 );
 
 #[cfg(any(
+    feature = "stm32f031",
+    feature = "stm32f038",
+    feature = "stm32f042",
+    feature = "stm32f048",
+    feature = "stm32f051",
+    feature = "stm32f058",
+    feature = "stm32f071",
+    feature = "stm32f072",
+    feature = "stm32f078",
+    feature = "stm32f091",
+    feature = "stm32f098",
+))]
+channel_impl!(
+    TIM2, PinC1, PA0, Alternate<AF2>;
+    TIM2, PinC2, PA1, Alternate<AF2>;
+    TIM2, PinC3, PA2, Alternate<AF2>;
+    TIM2, PinC4, PA3, Alternate<AF2>;
+    TIM2, PinC1, PA5, Alternate<AF2>;
+    TIM2, PinC1, PA15, Alternate<AF2>;
+    TIM2, PinC2, PB3, Alternate<AF2>;
+    TIM2, PINC3, PB10, Alternate<AF2>;
+    TIM2, PINC4, PB11, Alternate<AF2>;
+);
+
+#[cfg(any(
     feature = "stm32f030x8",
     feature = "stm32f030xc",
     feature = "stm32f051",


### PR DESCRIPTION
This adds support for the PWM output of TIM2 on supported devices. It is simply a matter of providing the corresponding implementations for the correct Pins and a pwm_4_channels implementation for TIM2. 