### PR TITLE
Fix ADC Example Temperature Conversion

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+- `adc_values` example conversion error
+
 ### Added
 
 - PWM complementary output capability for TIM1 with new example to demonstrate

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,13 +7,6 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased]
 
-### Fixed
-- `adc_values` example conversion error
-
-### Added
-
-- PWM complementary output capability for TIM1 with new example to demonstrate
-
 ### Changed
 
 - Updated the `cast` dependency from 0.2 to 0.3
@@ -22,10 +15,12 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Provide getters to serial status flags idle/txe/rxne/tc.
 - Provide ability to reset timer UIF interrupt flag
+- PWM complementary output capability for TIM1 with new example to demonstrate
 
 ### Fixed
 
 - Wrong mode when using PWM channel 2 of a two-channel timer
+- `adc_values` example conversion error
 
 ## [v0.18.0] - 2021-11-14
 

--- a/examples/adc_values.rs
+++ b/examples/adc_values.rs
@@ -79,7 +79,7 @@ fn SysTick() {
         if let Some(ref mut shared) = SHARED.borrow(cs).borrow_mut().deref_mut() {
             // Read temperature data from internal sensor using ADC
             let t = hal::adc::VTemp::read(&mut shared.adc, None);
-            writeln!(shared.tx, "Temperature {}.{}C\r", t / 100, t % 100).ok();
+            writeln!(shared.tx, "Temperature {}.{}C\r", t / 10, t % 10).ok();
 
             // Read volatage reference data from internal sensor using ADC
             let t = hal::adc::VRef::read_vdda(&mut shared.adc);


### PR DESCRIPTION
## Motivation
- The `adc_values` example had a conversion error. `VTemp` is in 10th's of a degree, not hundredths

## Change(s)
- Line `82` replace `100` with `10`