### PR TITLE
Fix compilation error in spi.rs for rust Version 1.73+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Wrong mode when using PWM channel 2 of a two-channel timer
 - `adc_values` example conversion error
+- `invalid_reference_casting` Compilation error in spi.rs for Rust version 1.73+ (
+  See [PR#112431](https://github.com/rust-lang/rust/pull/112431) for more info)
+- `unused_doc_comments` Warning in rcc.rs
 
 ## [v0.18.0] - 2021-11-14
 
@@ -254,19 +257,35 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Interrupt handler to new #[interrupt] attribute
 
 [Unreleased]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.18.0...HEAD
+
 [v0.18.0]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.17.1...v0.18.0
+
 [v0.17.1]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.17.0...v0.17.1
+
 [v0.17.0]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.16.0...v0.17.0
+
 [v0.16.0]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.15.2...v0.16.0
+
 [v0.15.2]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.15.1...v0.15.2
+
 [v0.15.1]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.15.0...v0.15.1
+
 [v0.15.0]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.14.1...v0.15.0
+
 [v0.14.1]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.14.0...v0.14.1
+
 [v0.14.0]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.13.0...v0.14.0
+
 [v0.13.0]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.12.0...v0.13.0
+
 [v0.12.0]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.11.1...v0.12.0
+
 [v0.11.1]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.11.0...v0.11.1
+
 [v0.11.0]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.10.1...v0.11.0
+
 [v0.10.1]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.10.0...v0.10.1
+
 [v0.10.0]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.9.0...v0.10.0
+
 [v0.9.0]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.8.0...v0.9.0

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -257,35 +257,19 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Interrupt handler to new #[interrupt] attribute
 
 [Unreleased]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.18.0...HEAD
-
 [v0.18.0]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.17.1...v0.18.0
-
 [v0.17.1]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.17.0...v0.17.1
-
 [v0.17.0]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.16.0...v0.17.0
-
 [v0.16.0]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.15.2...v0.16.0
-
 [v0.15.2]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.15.1...v0.15.2
-
 [v0.15.1]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.15.0...v0.15.1
-
 [v0.15.0]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.14.1...v0.15.0
-
 [v0.14.1]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.14.0...v0.14.1
-
 [v0.14.0]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.13.0...v0.14.0
-
 [v0.13.0]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.12.0...v0.13.0
-
 [v0.12.0]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.11.1...v0.12.0
-
 [v0.11.1]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.11.0...v0.11.1
-
 [v0.11.0]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.10.1...v0.11.0
-
 [v0.10.1]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.10.0...v0.10.1
-
 [v0.10.0]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.9.0...v0.10.0
-
 [v0.9.0]: https://github.com/stm32-rs/stm32f0xx-hal/compare/v0.8.0...v0.9.0

--- a/src/rcc.rs
+++ b/src/rcc.rs
@@ -14,7 +14,7 @@ impl RccExt for RCC {
             pclk: None,
             sysclk: None,
             clock_src: SysClkSource::HSI,
-            /// CRS is only available on devices with HSI48
+            // CRS is only available on devices with HSI48
             #[cfg(any(
                 feature = "stm32f042",
                 feature = "stm32f048",

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -413,10 +413,7 @@ where
 
     fn send_u8(&mut self, byte: u8) {
         // NOTE(write_volatile) see note above
-        #[allow(invalid_reference_casting)]
-        unsafe {
-            ptr::write_volatile(&self.spi.dr as *const _ as *mut u8, byte)
-        }
+        unsafe { ptr::write_volatile(ptr::addr_of!(self.spi.dr) as *mut u8, byte) }
     }
 
     fn read_u16(&mut self) -> u16 {
@@ -426,10 +423,7 @@ where
 
     fn send_u16(&mut self, byte: u16) {
         // NOTE(write_volatile) see note above
-        #[allow(invalid_reference_casting)]
-        unsafe {
-            ptr::write_volatile(&self.spi.dr as *const _ as *mut u16, byte)
-        }
+        unsafe { ptr::write_volatile(ptr::addr_of!(self.spi.dr) as *mut u16, byte) }
     }
 
     pub fn release(self) -> (SPI, (SCKPIN, MISOPIN, MOSIPIN)) {

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -413,7 +413,10 @@ where
 
     fn send_u8(&mut self, byte: u8) {
         // NOTE(write_volatile) see note above
-        unsafe { ptr::write_volatile(&self.spi.dr as *const _ as *mut u8, byte) }
+        #[allow(invalid_reference_casting)]
+        unsafe {
+            ptr::write_volatile(&self.spi.dr as *const _ as *mut u8, byte)
+        }
     }
 
     fn read_u16(&mut self) -> u16 {
@@ -423,7 +426,10 @@ where
 
     fn send_u16(&mut self, byte: u16) {
         // NOTE(write_volatile) see note above
-        unsafe { ptr::write_volatile(&self.spi.dr as *const _ as *mut u16, byte) }
+        #[allow(invalid_reference_casting)]
+        unsafe {
+            ptr::write_volatile(&self.spi.dr as *const _ as *mut u16, byte)
+        }
     }
 
     pub fn release(self) -> (SPI, (SCKPIN, MISOPIN, MOSIPIN)) {


### PR DESCRIPTION
With rust version 1.73.0 the `invalid_reference_casting` lint was set to deny by default. (See [PR#112431](https://github.com/rust-lang/rust/pull/112431). This causes the build process of this crate to fail to build spi.rs (only when building the crate with its examples, when adding it as a dependency works fine from what i can see).

This change fixes the compilation by adding the `[allow(invalid_reference_casting)]` attribute to the relevant parts.

This also fixes a `unused doc comment` compilation warning in rcc.rs

# NOTE

I have not tested this on hardware, just added the attribute to fix the compilation. 