### PR TITLE
Add PWM standalone output on complementary PWM Channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 ### Added
 
 - PWM complementary output capability for TIM1 with new example to demonstrate
+- PWM output on complementary channels only for single channel timers (TIM16 + TIM17)
 
 ### Changed
 

--- a/src/timers.rs
+++ b/src/timers.rs
@@ -327,6 +327,7 @@ channel_impl!(
 
     TIM16, PinC1, PA6, Alternate<AF5>;
     TIM16, PinC1, PB8, Alternate<AF2>;
+    TIM16, PinC1N, PB6, Alternate<AF2>;
 
     TIM17, PinC1, PA7, Alternate<AF5>;
     TIM17, PinC1, PB9, Alternate<AF2>;


### PR DESCRIPTION
This adds the option to use the complementary PWM Channels of Timers with 1 Channel and a complementary output in standalone mode. (E.g. using CH1N (PB6) of TIM16 without using CH1)

This has been tested and is working on a STM32F072B-DISCO board.

*NOTE:* The CI will probably fail until #170 or an alternative is merged.