### PR TITLE
Implement interface to internal flash storage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - Provide getters to serial status flags idle/txe/rxne/tc.
 - Provide ability to reset timer UIF interrupt flag
 - PWM complementary output capability for TIM1 with new example to demonstrate
+- Implement interface for reading and writing to the internal flash memory and an example for demonstration.
 
 ### Fixed
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -39,6 +39,7 @@ nb = "1"
 void = { version = "1.0", default-features = false }
 stm32-usbd = { version = "0.6", optional = true }
 bxcan = "0.6.0"
+embedded-storage = "0.3.0"
 
 [dev-dependencies]
 cortex-m-rt = "0.7"

--- a/examples/flash_read_write.rs
+++ b/examples/flash_read_write.rs
@@ -4,10 +4,14 @@
 use panic_halt as _;
 use stm32f0xx_hal as hal;
 
-use crate::hal::{flash::FlashExt, pac, prelude::*};
+use crate::hal::{
+    flash::{FlashExt, LockedFlash},
+    pac,
+    prelude::*,
+};
 
 use cortex_m_rt::entry;
-use embedded_storage::nor_flash::NorFlash;
+use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
 
 #[entry]
 fn main() -> ! {
@@ -15,36 +19,46 @@ fn main() -> ! {
         let _ = p.RCC.configure().freeze(&mut p.FLASH);
 
         // All examples use the first 16K of flash for the program so we use the first page after that
-        const OFFSET_START: u32 = 32 * 1024;
+        const OFFSET_START: u32 = 16 * 1024;
         const OFFSET_END: u32 = OFFSET_START + 1024;
         // Unlock flash before writing
         let mut unlocked_flash = p.FLASH.unlocked();
 
         NorFlash::erase(&mut unlocked_flash, OFFSET_START, OFFSET_END).unwrap();
-        NorFlash::erase(&mut unlocked_flash, 0x10000, 0x10000 + 1024).unwrap();
 
         // Write some data to the start of that page
         let write_data = [0xC0_u8, 0xFF_u8, 0xEE_u8, 0x00_u8];
         match NorFlash::write(&mut unlocked_flash, OFFSET_START, &write_data) {
-            Err(e) => {
-                let err = e;
-                loop {}
-            }
+            Err(_) => panic!(),
             Ok(_) => (),
         }
+
+        // Read back the written data from flash
+        let mut read_buffer: [u8; 4] = [0; 4];
+        unlocked_flash.read(OFFSET_START, &mut read_buffer).unwrap();
+        assert_eq!(write_data, read_buffer);
 
         // Lock flash by dropping it
         drop(unlocked_flash);
 
-        // Read back the slice from flash
+        // It is also possible to read "manually" using core functions
         let read_data = unsafe {
             core::slice::from_raw_parts(
-                (p.FLASH.address() + 16 * 1024) as *const u8,
+                (p.FLASH.address() + OFFSET_START as usize) as *const u8,
                 write_data.len(),
             )
         };
+        for (i, d) in read_data.iter().enumerate() {
+            read_buffer[i] = *d;
+        }
 
-        assert_eq!(write_data, *read_data);
+        assert_eq!(write_data, read_buffer);
+
+        // Reading is also possible on locked flash
+        let mut locked_flash = LockedFlash::new(p.FLASH);
+        locked_flash.read(OFFSET_START, &mut read_buffer).unwrap();
+
+        assert_eq!(write_data, read_buffer);
     }
     loop {
         continue;

--- a/examples/flash_read_write.rs
+++ b/examples/flash_read_write.rs
@@ -20,12 +20,12 @@ fn main() -> ! {
     if let Some(mut p) = pac::Peripherals::take() {
         let _ = p.RCC.configure().freeze(&mut p.FLASH);
 
-        const OFFSET_START: u32 = 32 * 1024;
-        const OFFSET_END: u32 = 33 * 1024;
+        // All examples use the first 16K of flash for the program so we use the first page after that
+        const OFFSET_START: u32 = 16 * 1024;
+        const OFFSET_END: u32 = OFFSET_START + 1024;
         // Unlock flash before writing
         let mut unlocked_flash = p.FLASH.unlocked();
 
-        // All examples use the first 16K of flash for the program so we use the first page after that
         NorFlash::erase(&mut unlocked_flash, OFFSET_START, OFFSET_END).unwrap();
 
         // Write some data to the start of that page

--- a/examples/flash_read_write.rs
+++ b/examples/flash_read_write.rs
@@ -13,10 +13,16 @@ use crate::hal::{
 use cortex_m_rt::entry;
 use embedded_storage::nor_flash::{NorFlash, ReadNorFlash};
 
+/// # NOTE
+/// This example assumes a flash size of more than 16K. If your MCU has less or equal than 16K Bytes
+/// of flash memory, adjust the `memory.x` file and `OFFSET_START` + `OFFSET_END` constants accordingly.
 #[entry]
 fn main() -> ! {
     if let Some(mut p) = pac::Peripherals::take() {
         let _ = p.RCC.configure().freeze(&mut p.FLASH);
+
+        // Check that flash is big enough for this example
+        assert!(p.FLASH.len() > 16 * 1024);
 
         // All examples use the first 16K of flash for the program so we use the first page after that
         const OFFSET_START: u32 = 16 * 1024;

--- a/examples/flash_read_write.rs
+++ b/examples/flash_read_write.rs
@@ -1,0 +1,51 @@
+#![no_main]
+#![no_std]
+
+use cortex_m::Peripherals;
+use panic_halt as _;
+use stm32f0xx_hal as hal;
+
+use crate::hal::{
+    pac::{self, flash},
+    prelude::*,
+};
+
+use cortex_m_rt::entry;
+use embedded_storage::nor_flash::NorFlash;
+use stm32f0xx_hal::flash::FlashExt;
+use stm32f0xx_hal::prelude::_stm32f0xx_hal_rcc_RccExt;
+
+#[entry]
+fn main() -> ! {
+    if let Some(mut p) = pac::Peripherals::take() {
+        let _ = p.RCC.configure().freeze(&mut p.FLASH);
+
+        const OFFSET_START: u32 = 32 * 1024;
+        const OFFSET_END: u32 = 33 * 1024;
+        // Unlock flash before writing
+        let mut unlocked_flash = p.FLASH.unlocked();
+
+        // All examples use the first 16K of flash for the program so we use the first page after that
+        NorFlash::erase(&mut unlocked_flash, OFFSET_START, OFFSET_END).unwrap();
+
+        // Write some data to the start of that page
+        let write_data = [0xC0_u8, 0xFF_u8, 0xEE_u8, 0x00_u8];
+        NorFlash::write(&mut unlocked_flash, OFFSET_START, &write_data).unwrap();
+
+        // Lock flash by dropping it
+        drop(unlocked_flash);
+
+        // Read back the slice from flash
+        let read_data = unsafe {
+            core::slice::from_raw_parts(
+                (p.FLASH.address() + 16 * 1024) as *const u8,
+                write_data.len(),
+            )
+        };
+
+        assert_eq!(write_data, *read_data);
+    }
+    loop {
+        continue;
+    }
+}

--- a/examples/flash_read_write.rs
+++ b/examples/flash_read_write.rs
@@ -1,19 +1,13 @@
 #![no_main]
 #![no_std]
 
-use cortex_m::Peripherals;
 use panic_halt as _;
 use stm32f0xx_hal as hal;
 
-use crate::hal::{
-    pac::{self, flash},
-    prelude::*,
-};
+use crate::hal::{flash::FlashExt, pac, prelude::*};
 
 use cortex_m_rt::entry;
 use embedded_storage::nor_flash::NorFlash;
-use stm32f0xx_hal::flash::FlashExt;
-use stm32f0xx_hal::prelude::_stm32f0xx_hal_rcc_RccExt;
 
 #[entry]
 fn main() -> ! {
@@ -21,16 +15,23 @@ fn main() -> ! {
         let _ = p.RCC.configure().freeze(&mut p.FLASH);
 
         // All examples use the first 16K of flash for the program so we use the first page after that
-        const OFFSET_START: u32 = 16 * 1024;
+        const OFFSET_START: u32 = 32 * 1024;
         const OFFSET_END: u32 = OFFSET_START + 1024;
         // Unlock flash before writing
         let mut unlocked_flash = p.FLASH.unlocked();
 
         NorFlash::erase(&mut unlocked_flash, OFFSET_START, OFFSET_END).unwrap();
+        NorFlash::erase(&mut unlocked_flash, 0x10000, 0x10000 + 1024).unwrap();
 
         // Write some data to the start of that page
         let write_data = [0xC0_u8, 0xFF_u8, 0xEE_u8, 0x00_u8];
-        NorFlash::write(&mut unlocked_flash, OFFSET_START, &write_data).unwrap();
+        match NorFlash::write(&mut unlocked_flash, OFFSET_START, &write_data) {
+            Err(e) => {
+                let err = e;
+                loop {}
+            }
+            Ok(_) => (),
+        }
 
         // Lock flash by dropping it
         drop(unlocked_flash);

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -215,7 +215,7 @@ impl WriteErase for UnlockedFlash<'_> {
             self.flash.cr.modify(|_, w| w.pg().set_bit());
             unsafe {
                 ptr::write_volatile(addr, half_word);
-                addr = addr.add(mem::size_of::<Self::NativeType>());
+                addr = addr.add(1);
             }
         }
 

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -1,0 +1,395 @@
+use core::convert::TryInto;
+use core::{ptr, slice};
+
+use embedded_storage::nor_flash::{
+    ErrorType, MultiwriteNorFlash, NorFlash, NorFlashError, NorFlashErrorKind, ReadNorFlash,
+};
+
+use crate::pac::FLASH;
+use crate::signature::FlashSize;
+
+/// Flash erase/program error
+#[derive(Debug, Clone, Copy)]
+pub enum Error {
+    Programming,
+    WriteProtection,
+}
+
+impl Error {
+    fn read(flash: &FLASH) -> Option<Self> {
+        let sr = flash.sr.read();
+        if sr.pgerr().bit() {
+            Some(Error::Programming)
+        } else if sr.wrprt().bit() {
+            Some(Error::WriteProtection)
+        } else {
+            None
+        }
+    }
+}
+
+/// Flash methods implemented for `pac::FLASH`
+#[allow(clippy::len_without_is_empty)]
+pub trait FlashExt {
+    /// Memory-mapped address
+    fn address(&self) -> usize;
+    /// Size in bytes
+    fn len(&self) -> usize;
+    /// Returns a read-only view of flash memory
+    fn read(&self) -> &[u8] {
+        let ptr = self.address() as *const _;
+        unsafe { slice::from_raw_parts(ptr, self.len()) }
+    }
+    /// Unlock flash for erasing/programming until this method's
+    /// result is dropped
+    fn unlocked(&mut self) -> UnlockedFlash;
+    /// Returns flash memory sector of a given offset. Returns none if offset is out of range.
+    fn sector(&self, offset: usize) -> Option<FlashSector>;
+}
+
+impl FlashExt for FLASH {
+    fn address(&self) -> usize {
+        0x0800_0000
+    }
+
+    fn len(&self) -> usize {
+        FlashSize::get().bytes()
+    }
+
+    fn unlocked(&mut self) -> UnlockedFlash {
+        unlock(self);
+        UnlockedFlash { flash: self }
+    }
+
+    fn sector(&self, offset: usize) -> Option<FlashSector> {
+        flash_sectors(self.len()).find(|s| s.contains(offset))
+    }
+}
+
+/// Read-only flash
+///
+/// # Examples
+///
+/// ```
+/// use stm32f0xx_hal::pac::Peripherals;
+/// use stm32f0xx_hal::flash::LockedFlash;
+/// use embedded_storage::nor_flash::ReadNorFlash;
+///
+/// let dp = Peripherals::take().unwrap();
+/// let mut flash = LockedFlash::new(dp.FLASH);
+/// println!("Flash capacity: {}", ReadNorFlash::capacity(&flash));
+///
+/// let mut buf = [0u8; 64];
+/// ReadNorFlash::read(&mut flash, 0x0, &mut buf).unwrap();
+/// println!("First 64 bytes of flash memory: {:?}", buf);
+/// ```
+pub struct LockedFlash {
+    flash: FLASH,
+}
+
+impl LockedFlash {
+    pub fn new(flash: FLASH) -> Self {
+        Self { flash }
+    }
+}
+
+impl FlashExt for LockedFlash {
+    fn address(&self) -> usize {
+        self.flash.address()
+    }
+
+    fn len(&self) -> usize {
+        self.flash.len()
+    }
+
+    fn unlocked(&mut self) -> UnlockedFlash {
+        self.flash.unlocked()
+    }
+
+    fn sector(&self, offset: usize) -> Option<FlashSector> {
+        self.flash.sector(offset)
+    }
+}
+
+/// Result of `FlashExt::unlocked()`
+///
+/// # Examples
+///
+/// ```
+/// use stm32f0xx_hal::pac::Peripherals;
+/// use stm32f0xx_hal::flash::{FlashExt, LockedFlash, UnlockedFlash};
+/// use embedded_storage::nor_flash::NorFlash;
+///
+/// let dp = Peripherals::take().unwrap();
+/// let mut flash = LockedFlash::new(dp.FLASH);
+///
+/// // Unlock flash for writing
+/// let mut unlocked_flash = flash.unlocked();
+///
+/// // Erase the second 128 KB sector.
+/// NorFlash::erase(&mut unlocked_flash, 128 * 1024, 256 * 1024).unwrap();
+///
+/// // Write some data at the start of the second 128 KB sector.
+/// let buf = [0u8; 64];
+/// NorFlash::write(&mut unlocked_flash, 128 * 1024, &buf).unwrap();
+///
+/// // Lock flash by dropping
+/// drop(unlocked_flash);
+/// ```
+pub struct UnlockedFlash<'a> {
+    flash: &'a mut FLASH,
+}
+
+/// Automatically lock flash erase/program when leaving scope
+impl Drop for UnlockedFlash<'_> {
+    fn drop(&mut self) {
+        lock(self.flash);
+    }
+}
+
+impl UnlockedFlash<'_> {
+    /// Erase a flash page at offset
+    ///
+    /// Refer to the reference manual to see which sector corresponds
+    /// to which memory address.
+    pub fn erase(&mut self, offset: u32) -> Result<(), Error> {
+        // Write address into the AR register
+        self.flash
+            .ar
+            .write(|w| w.far().bits(self.flash.address() as u32 + offset));
+        #[rustfmt::skip]
+        self.flash.cr.modify(|_, w|
+            w
+                // page erase
+                .per().set_bit()
+                // start
+                .strt().set_bit()
+        );
+        self.wait_ready();
+        // Clear PER bit after operation is finished
+        self.flash.cr.modify(|_, w| w.per().clear_bit());
+        self.ok()
+    }
+
+    /// Program bytes with offset into flash memory
+    pub fn program<'a, I>(&mut self, mut offset: usize, mut bytes: I) -> Result<(), Error>
+    where
+        I: Iterator<Item = &'a u8>,
+    {
+        if self.flash.cr.read().lock().bit_is_set() {
+            return Err(Error::Programming);
+        }
+        let ptr = self.flash.address() as *mut u8;
+        let mut bytes_written = 1;
+        while bytes_written > 0 {
+            bytes_written = 0;
+            let amount = 2 - (offset % 2);
+
+            #[allow(unused_unsafe)]
+            self.flash.cr.modify(|_, w| unsafe {
+                // programming
+                w.pg().set_bit()
+            });
+            for _ in 0..amount {
+                match bytes.next() {
+                    Some(byte) => {
+                        unsafe {
+                            ptr::write_volatile(ptr.add(offset), *byte);
+                        }
+                        offset += 1;
+                        bytes_written += 1;
+                    }
+                    None => break,
+                }
+            }
+            self.wait_ready();
+            self.ok()?;
+        }
+        self.flash.cr.modify(|_, w| w.pg().clear_bit());
+
+        Ok(())
+    }
+
+    fn ok(&self) -> Result<(), Error> {
+        Error::read(self.flash).map(Err).unwrap_or(Ok(()))
+    }
+
+    fn wait_ready(&self) {
+        while self.flash.sr.read().bsy().bit() {}
+    }
+}
+
+const UNLOCK_KEY1: u32 = 0x45670123;
+const UNLOCK_KEY2: u32 = 0xCDEF89AB;
+
+#[allow(unused_unsafe)]
+fn unlock(flash: &FLASH) {
+    flash.keyr.write(|w| unsafe { w.fkeyr().bits(UNLOCK_KEY1) });
+    flash.keyr.write(|w| unsafe { w.fkeyr().bits(UNLOCK_KEY2) });
+    assert!(!flash.cr.read().lock().bit())
+}
+
+fn lock(flash: &FLASH) {
+    flash.cr.modify(|_, w| w.lock().set_bit());
+}
+
+/// Flash memory sector
+pub struct FlashSector {
+    /// Sector number
+    pub number: u8,
+    /// Offset from base memory address
+    pub offset: usize,
+    /// Sector size in bytes
+    pub size: usize,
+}
+
+impl FlashSector {
+    /// Returns true if given offset belongs to this sector
+    pub fn contains(&self, offset: usize) -> bool {
+        self.offset <= offset && offset < self.offset + self.size
+    }
+}
+
+/// Iterator of flash memory sectors in a single bank.
+/// Yields a size sequence of [16, 16, 16, 64, 128, 128, ..]
+pub struct FlashSectorIterator {
+    index: u8,
+    start_sector: u8,
+    start_offset: usize,
+    end_offset: usize,
+}
+
+impl FlashSectorIterator {
+    fn new(start_sector: u8, start_offset: usize, end_offset: usize) -> Self {
+        Self {
+            index: 0,
+            start_sector,
+            start_offset,
+            end_offset,
+        }
+    }
+}
+
+impl Iterator for FlashSectorIterator {
+    type Item = FlashSector;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if self.start_offset >= self.end_offset {
+            None
+        } else {
+            // F03x, F04x and F05x sectors are 1K long
+            #[cfg(any(
+                feature = "stm32f030",
+                feature = "stm32f031",
+                feature = "stm32f038",
+                feature = "stm32f042",
+                feature = "stm32f048",
+                feature = "stm32f051",
+                feature = "stm32f058",
+            ))]
+            let size = 1024;
+
+            // F07x and F09x sectors are 2K long
+            #[cfg(any(
+                feature = "stm32f070",
+                feature = "stm32f071",
+                feature = "stm32f072",
+                feature = "stm32f078",
+                feature = "stm32f091",
+                feature = "stm32f098",
+            ))]
+            let size = 2048;
+
+            let sector = FlashSector {
+                number: self.start_sector + self.index,
+                offset: self.start_offset,
+                size,
+            };
+
+            self.index += 1;
+            self.start_offset += size;
+
+            Some(sector)
+        }
+    }
+}
+
+/// Returns iterator of flash memory sectors for single and dual bank flash.
+/// Sectors are returned in continuous memory order, while sector numbers can have spaces between banks.
+pub fn flash_sectors(flash_size: usize) -> impl Iterator<Item = FlashSector> {
+    // Chain an empty iterator to match types
+    FlashSectorIterator::new(0, 0, flash_size).chain(FlashSectorIterator::new(0, 0, 0))
+}
+
+impl NorFlashError for Error {
+    fn kind(&self) -> NorFlashErrorKind {
+        NorFlashErrorKind::Other
+    }
+}
+
+impl ErrorType for LockedFlash {
+    type Error = Error;
+}
+
+impl ErrorType for UnlockedFlash<'_> {
+    type Error = Error;
+}
+
+impl ReadNorFlash for LockedFlash {
+    const READ_SIZE: usize = 1;
+
+    fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+        let offset = offset as usize;
+        bytes.copy_from_slice(&self.flash.read()[offset..offset + bytes.len()]);
+        Ok(())
+    }
+
+    fn capacity(&self) -> usize {
+        self.flash.len()
+    }
+}
+
+impl<'a> ReadNorFlash for UnlockedFlash<'a> {
+    const READ_SIZE: usize = 1;
+
+    fn read(&mut self, offset: u32, bytes: &mut [u8]) -> Result<(), Self::Error> {
+        let offset = offset as usize;
+        bytes.copy_from_slice(&self.flash.read()[offset..offset + bytes.len()]);
+        Ok(())
+    }
+
+    fn capacity(&self) -> usize {
+        self.flash.len()
+    }
+}
+
+impl<'a> NorFlash for UnlockedFlash<'a> {
+    const WRITE_SIZE: usize = 1;
+
+    // Use largest sector size of 128 KB. All smaller sectors will be erased together.
+    const ERASE_SIZE: usize = 128 * 1024;
+
+    fn erase(&mut self, from: u32, to: u32) -> Result<(), Self::Error> {
+        let mut current = from as usize;
+
+        for sector in flash_sectors(self.flash.len()) {
+            if sector.contains(current) {
+                UnlockedFlash::erase(self, current as u32)?;
+                current += sector.size;
+            }
+
+            if current >= to as usize {
+                break;
+            }
+        }
+
+        Ok(())
+    }
+
+    fn write(&mut self, offset: u32, bytes: &[u8]) -> Result<(), Self::Error> {
+        self.program(offset as usize, bytes.iter())
+    }
+}
+
+// STM32F4 supports multiple writes
+impl<'a> MultiwriteNorFlash for UnlockedFlash<'a> {}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -59,6 +59,8 @@ pub mod time;
 #[cfg(feature = "device-selected")]
 pub mod timers;
 #[cfg(feature = "device-selected")]
+pub mod flash;
+#[cfg(feature = "device-selected")]
 pub mod signature;
 #[cfg(any(
     feature = "stm32f031",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -58,6 +58,8 @@ pub mod spi;
 pub mod time;
 #[cfg(feature = "device-selected")]
 pub mod timers;
+#[cfg(feature = "device-selected")]
+pub mod signature;
 #[cfg(any(
     feature = "stm32f031",
     feature = "stm32f051",

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -41,6 +41,8 @@ pub mod dac;
 #[cfg(feature = "device-selected")]
 pub mod delay;
 #[cfg(feature = "device-selected")]
+pub mod flash;
+#[cfg(feature = "device-selected")]
 pub mod gpio;
 #[cfg(feature = "device-selected")]
 pub mod i2c;
@@ -53,15 +55,13 @@ pub mod rcc;
 #[cfg(feature = "device-selected")]
 pub mod serial;
 #[cfg(feature = "device-selected")]
+pub mod signature;
+#[cfg(feature = "device-selected")]
 pub mod spi;
 #[cfg(feature = "device-selected")]
 pub mod time;
 #[cfg(feature = "device-selected")]
 pub mod timers;
-#[cfg(feature = "device-selected")]
-pub mod flash;
-#[cfg(feature = "device-selected")]
-pub mod signature;
 #[cfg(any(
     feature = "stm32f031",
     feature = "stm32f051",

--- a/src/signature.rs
+++ b/src/signature.rs
@@ -1,0 +1,80 @@
+//! Device electronic signature
+//!
+//! (stored in flash memory)
+
+use core::str::from_utf8_unchecked;
+
+/// This is the test voltage in millivolts of the calibration done at the factory
+pub const VDDA_CALIB: u32 = 3300;
+
+macro_rules! define_ptr_type {
+    ($name: ident, $ptr: expr) => {
+        impl $name {
+            fn ptr() -> *const Self {
+                $ptr as *const _
+            }
+
+            /// Returns a wrapped reference to the value in flash memory
+            pub fn get() -> &'static Self {
+                unsafe { &*Self::ptr() }
+            }
+        }
+    };
+}
+
+// f030 and f070 don't have a UID in ROM
+#[cfg(not(any(feature = "stm32f030", feature = "stm32f070")))]
+#[derive(Hash, Debug)]
+#[repr(C)]
+pub struct Uid {
+    x: u16,
+    y: u16,
+    waf_lot: [u8; 8],
+}
+#[cfg(not(any(feature = "stm32f030", feature = "stm32f070")))]
+define_ptr_type!(Uid, 0x1FFF_F7AC);
+
+/// Device UID from ROM. See the [reference manual](https://www.st.com/content/ccc/resource/technical/document/reference_manual/c2/f8/8a/f2/18/e6/43/96/DM00031936.pdf/files/DM00031936.pdf/jcr:content/translations/en.DM00031936.pdf#%5B%7B%22num%22%3A1575%2C%22gen%22%3A0%7D%2C%7B%22name%22%3A%22XYZ%22%7D%2C67%2C755%2Cnull%5D) for more info.
+#[cfg(not(any(feature = "stm32f030", feature = "stm32f070")))]
+impl Uid {
+    /// X coordinate on wafer
+    pub fn x(&self) -> u16 {
+        self.x
+    }
+
+    /// Y coordinate on wafer
+    pub fn y(&self) -> u16 {
+        self.y
+    }
+
+    /// Wafer number
+    pub fn waf_num(&self) -> u8 {
+        self.waf_lot[0]
+    }
+
+    /// Lot number
+    pub fn lot_num(&self) -> &str {
+        unsafe { from_utf8_unchecked(&self.waf_lot[1..]) }
+    }
+}
+
+/// Size of integrated flash
+#[derive(Debug)]
+#[repr(C)]
+pub struct FlashSize(u16);
+#[cfg(not(any(feature = "stm32f030", feature = "stm32f070")))]
+define_ptr_type!(FlashSize, 0x1FFF_F7CC);
+#[cfg(any(feature = "stm32f030", feature = "stm32f070"))]
+define_ptr_type!(FlashSize, 0x1FFF_0000);
+
+impl FlashSize {
+    /// Read flash size in kilobytes
+    pub fn kilo_bytes(&self) -> u16 {
+        self.0
+    }
+
+    /// Read flash size in bytes
+    pub fn bytes(&self) -> usize {
+        usize::from(self.kilo_bytes()) * 1024
+    }
+}


### PR DESCRIPTION
This implements an interface to reading and writing to the internal flash memory. This implements the [`NorFlash` traits](https://github.com/rust-embedded-community/embedded-storage/blob/master/src/nor_flash.rs) from the [`embedded-storage` crate](https://docs.rs/embedded-storage/latest/embedded_storage/).

The interface is inspired by the interfaces used in the [`stm32f4xx-hal`](https://github.com/stm32-rs/stm32f4xx-hal/blob/master/src/flash.rs) and the [`stm32g0xx-hal`](https://github.com/stm32-rs/stm32g0xx-hal/blob/main/src/flash/mod.rs). 

The interface could definitely use some clean up and I'm open to suggestions on that matter. Especially the handling of [writing to addresses not aligned to the native write size](https://github.com/JanekGraff/stm32f0xx-hal/blob/2769e82dfa8e42b74f7e367601d5bc5d2873d36d/src/flash.rs#L231) is something I'm not sure about. The `stm32g0xx-hal` has a [different approach](https://github.com/stm32-rs/stm32g0xx-hal/blob/e6145ef83c639e736556fb4775f349aef7100ad6/src/flash/mod.rs#L166) for this, but their approach has some problems in my opinion:

1. Trying to write data that is shorter than the unaligned size (e.g. writing 3 Bytes to `0x08008001`) will lead to a panic due to the slice index being out of range.
2. *(I'm not 100% sure about this)* It seems like they will write unaligned data to an address that is in front of the address given by the user, which is not intuitive in my opinion.
3. Passing an unaligned address to the write function will lead to some of the data in front of the address being overwritten.

The reasons above are why i choose the approach of returning an Error instead of trying to pad the data into native writes.

I also provided a [basic example](https://github.com/JanekGraff/stm32f0xx-hal/blob/flash/examples/flash_read_write.rs) of how to use the flash interface.


The CI checks of this PR will fail until #170 (or an alternative solution) is merged.