### PR TITLE
Update bxcan dependency to 0.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 - Updated the `cast` dependency from 0.2 to 0.3
 - Updated `stm32f0` peripheral access crate from 0.14 to 0.15
+- Updated `bxcan` dependency from 0.6.0 to 0.8.0
 
 ### Added
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -38,7 +38,7 @@ stm32f0 = "0.15"
 nb = "1"
 void = { version = "1.0", default-features = false }
 stm32-usbd = { version = "0.6", optional = true }
-bxcan = "0.6.0"
+bxcan = "0.8.0"
 embedded-storage = "0.3.0"
 
 [dev-dependencies]


### PR DESCRIPTION
This version implements the embedded-can traits.

See [#59 in bxcan](https://github.com/stm32-rs/bxcan/pull/59) for more info.