### PR TITLE
16 bits TIM2 PWM outputs implemented

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 
 ### Added
 
+- PWM output on TIM2 channels.
 - Provide getters to serial status flags idle/txe/rxne/tc.
 - Provide ability to reset timer UIF interrupt flag
 - PWM complementary output capability for TIM1 with new example to demonstrate

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -906,7 +906,21 @@ macro_rules! pwm_1_channel_with_complementary_outputs {
 
 use crate::pac::*;
 
+#[cfg(any(
+    feature = "stm32f031",
+    feature = "stm32f038",
+    feature = "stm32f042",
+    feature = "stm32f048",
+    feature = "stm32f051",
+    feature = "stm32f058",
+    feature = "stm32f071",
+    feature = "stm32f072",
+    feature = "stm32f078",
+    feature = "stm32f091",
+    feature = "stm32f098",
+))]
 pwm_4_channels!(TIM2: (tim2, tim2en, tim2rst, apb1enr, apb1rstr),);
+
 pwm_4_channels!(TIM3: (tim3, tim3en, tim3rst, apb1enr, apb1rstr),);
 
 pwm_4_channels_with_3_complementary_outputs!(TIM1: (tim1, tim1en, tim1rst, apb2enr, apb2rstr),);

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -906,6 +906,7 @@ macro_rules! pwm_1_channel_with_complementary_outputs {
 
 use crate::pac::*;
 
+pwm_4_channels!(TIM2: (tim2, tim2en, tim2rst, apb1enr, apb1rstr),);
 pwm_4_channels!(TIM3: (tim3, tim3en, tim3rst, apb1enr, apb1rstr),);
 
 pwm_4_channels_with_3_complementary_outputs!(TIM1: (tim1, tim1en, tim1rst, apb2enr, apb2rstr),);

--- a/src/timers.rs
+++ b/src/timers.rs
@@ -354,6 +354,26 @@ channel_impl!(
 );
 
 #[cfg(any(
+    feature = "stm32f031",
+    feature = "stm32f038",
+    feature = "stm32f042",
+    feature = "stm32f048",
+    feature = "stm32f051",
+    feature = "stm32f058",
+    feature = "stm32f071",
+    feature = "stm32f072",
+    feature = "stm32f078",
+    feature = "stm32f091",
+    feature = "stm32f098",
+))]
+channel_impl!(
+    TIM2, PinC1, PA0, Alternate<AF2>;
+    TIM2, PinC2, PA1, Alternate<AF2>;
+    TIM2, PinC3, PA2, Alternate<AF2>;
+    TIM2, PinC4, PA3, Alternate<AF2>;
+);
+
+#[cfg(any(
     feature = "stm32f030",
     feature = "stm32f051",
     feature = "stm32f058",


### PR DESCRIPTION
TIM2 PWM output pin definitions implemented for stm32f042 and similar.
Only caveat TIM2 is a 32 bits timer but this implementation treat it as 16 bits but still works OK.

Tested OK on stm32f042 hardware.