### PR TITLE
gpioe: AF1 enablement

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - PWM output on complementary channels only for single channel timers (TIM16 + TIM17)
 - impl embedded_hal_1::spi::SpiBus for SPI
 - impl embedded_hal_1::digital traits for Pins
+- Enable AF1 on GPIOE for pins [13, 14, 15] to support SPI communication
 
 ### Fixed
 

--- a/src/spi.rs
+++ b/src/spi.rs
@@ -136,23 +136,21 @@ spi_pins! {
         mosi => [gpiob::PB15<Alternate<AF0>>],
     }
 }
-// TODO: The ST SVD files are missing the entire PE enable register.
-//       So those pins do not exist in the register definitions.
-//       Re-enable as soon as this gets fixed.
-// #[cfg(any(
-//     feature = "stm32f071",
-//     feature = "stm32f072",
-//     feature = "stm32f078",
-//     feature = "stm32f091",
-//     feature = "stm32f098",
-// ))]
-// spi_pins! {
-//     SPI1 => {
-//         sck => [gpioe::PE13<Alternate<AF1>>],
-//         miso => [gpioe::PE14<Alternate<AF1>>],
-//         mosi => [gpioe::PE15<Alternate<AF1>>],
-//     }
-// }
+
+#[cfg(any(
+    feature = "stm32f071",
+    feature = "stm32f072",
+    feature = "stm32f078",
+    feature = "stm32f091",
+    feature = "stm32f098",
+))]
+spi_pins! {
+    SPI1 => {
+        sck => [gpioe::PE13<Alternate<AF1>>],
+        miso => [gpioe::PE14<Alternate<AF1>>],
+        mosi => [gpioe::PE15<Alternate<AF1>>],
+    }
+}
 
 #[cfg(any(
     feature = "stm32f030x8",


### PR DESCRIPTION
+ This commit reenables AF1 for pin 13, 14, 15 on GPIOE which is necessary for SPI communication.