### PR TITLE
Fix incorrect OSPEEDR register assignment for `into_push_pull_output_hs`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `invalid_reference_casting` Compilation error in spi.rs for Rust version 1.73+ (
   See [PR#112431](https://github.com/rust-lang/rust/pull/112431) for more info)
 - `unused_doc_comments` Warning in rcc.rs
+- Fixed incorrect OSPEEDR assignment for high-speed push-pull output
 - Fixed some warnings #177
 
 ## [v0.18.0] - 2021-11-14

--- a/src/gpio.rs
+++ b/src/gpio.rs
@@ -485,7 +485,7 @@ macro_rules! gpio {
                                     w.bits(r.bits() & !(0b1 << $i))
                                 });
                                 reg.ospeedr.modify(|r, w| {
-                                    w.bits(r.bits() & !(0b1 << $i))
+                                    w.bits(r.bits() | (0b11 << offset))
                                 });
                                 reg.moder.modify(|r, w| {
                                     w.bits((r.bits() & !(0b11 << offset)) | (0b01 << offset))


### PR DESCRIPTION
Fixes #191

This code appears to be incorrectly copied from the OTYPER assignment above it.