### PR TITLE
Implement Dead-Time Calculation for Complementary PWM Channels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - impl embedded_hal_1::spi::SpiBus for SPI
 - impl embedded_hal_1::digital traits for Pins
 - Enable AF1 on GPIOE for pins [13, 14, 15] to support SPI communication
+- Implement dead time calculations for complementary pwm
 
 ### Fixed
 

--- a/src/pwm.rs
+++ b/src/pwm.rs
@@ -484,10 +484,6 @@ macro_rules! pwm_4_channels_with_3_complementary_outputs {
 
                     unsafe { (*($TIMX::ptr())).bdtr.modify(|_, w| w.dtg().bits(dtg as u8)) };
                 }
-
-                fn calc_dead_time(&mut self) -> u8 {
-                    unsafe { (*($TIMX::ptr())).bdtr.read().dtg().bits() as u8 }
-                }
             }
 
             impl hal::PwmPin for PwmChannels<$TIMX, C2> {
@@ -537,10 +533,6 @@ macro_rules! pwm_4_channels_with_3_complementary_outputs {
                     };
 
                     unsafe { (*($TIMX::ptr())).bdtr.modify(|_, w| w.dtg().bits(dtg as u8)) };
-                }
-
-                fn calc_dead_time(&mut self) -> u8 {
-                    unsafe { (*($TIMX::ptr())).bdtr.read().dtg().bits() as u8 }
                 }
             }
 
@@ -592,10 +584,6 @@ macro_rules! pwm_4_channels_with_3_complementary_outputs {
 
                     unsafe { (*($TIMX::ptr())).bdtr.modify(|_, w| w.dtg().bits(dtg as u8)) };
                 }
-
-                fn calc_dead_time(&mut self) -> u8 {
-                    unsafe { (*($TIMX::ptr())).bdtr.read().dtg().bits() as u8 }
-                }
             }
 
             impl hal::PwmPin for PwmChannels<$TIMX, C3> {
@@ -646,10 +634,6 @@ macro_rules! pwm_4_channels_with_3_complementary_outputs {
 
                     unsafe { (*($TIMX::ptr())).bdtr.modify(|_, w| w.dtg().bits(dtg as u8)) };
                 }
-
-                fn calc_dead_time(&mut self) -> u8 {
-                    unsafe { (*($TIMX::ptr())).bdtr.read().dtg().bits() as u8 }
-                }
             }
 
             impl hal::PwmPin for PwmChannels<$TIMX, C3N> {
@@ -699,10 +683,6 @@ macro_rules! pwm_4_channels_with_3_complementary_outputs {
                     };
 
                     unsafe { (*($TIMX::ptr())).bdtr.modify(|_, w| w.dtg().bits(dtg as u8)) };
-                }
-
-                fn calc_dead_time(&mut self) -> u8 {
-                    unsafe { (*($TIMX::ptr())).bdtr.read().dtg().bits() as u8 }
                 }
             }
 


### PR DESCRIPTION
This PR adds methods to calculate and set the dead time for complementary pwm channels.  This feature became necessary in creating bldc firmware for [RoboJackets Robocup Motor Controller Firmware](https://github.com/RoboJackets/robocup-rustware/tree/main/motor-controller) so it was implemented locally and we are looking to push the changes upstream.