### PR TITLE
warnings: eliminated

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,8 @@ and this project adheres to [Semantic Versioning](http://semver.org/).
 - `invalid_reference_casting` Compilation error in spi.rs for Rust version 1.73+ (
   See [PR#112431](https://github.com/rust-lang/rust/pull/112431) for more info)
 - `unused_doc_comments` Warning in rcc.rs
+- `unused_unsafe` Warning in timers.rs (32-bit TIM2 shares the 16-bit timer macro)
+- `mismatched_lifetime_syntaxes` Warnings in flash.rs (`FlashExt::unlocked` returns `UnlockedFlash<'_>`)
 - Fixed incorrect OSPEEDR assignment for high-speed push-pull output
 - Fixed some warnings #177
 

--- a/src/flash.rs
+++ b/src/flash.rs
@@ -91,7 +91,7 @@ pub trait FlashExt {
     }
     /// Unlock flash for erasing/programming until this method's
     /// result is dropped
-    fn unlocked(&mut self) -> UnlockedFlash;
+    fn unlocked(&mut self) -> UnlockedFlash<'_>;
 }
 
 impl FlashExt for FLASH {
@@ -103,7 +103,7 @@ impl FlashExt for FLASH {
         FlashSize::get().bytes()
     }
 
-    fn unlocked(&mut self) -> UnlockedFlash {
+    fn unlocked(&mut self) -> UnlockedFlash<'_> {
         unlock(self);
         UnlockedFlash { flash: self }
     }
@@ -145,7 +145,7 @@ impl FlashExt for LockedFlash {
         self.flash.len()
     }
 
-    fn unlocked(&mut self) -> UnlockedFlash {
+    fn unlocked(&mut self) -> UnlockedFlash<'_> {
         self.flash.unlocked()
     }
 }

--- a/src/timers.rs
+++ b/src/timers.rs
@@ -201,6 +201,9 @@ macro_rules! timers {
                     self.tim.psc.write(|w| w.psc().bits(psc));
 
                     let arr = cast::u16(ticks / cast::u32(psc + 1)).unwrap();
+                    // `unsafe` is required for all the 16-bit timers
+                    // but redundant only for the 32-bit TIM2 that shares this macro body
+                    #[allow(unused_unsafe)]
                     self.tim.arr.write(|w| unsafe { w.bits(cast::u32(arr)) });
 
                     // start counter


### PR DESCRIPTION
- `unused_unsafe` Warning in timers.rs
- `mismatched_lifetime_syntaxes` Warnings in flash.rs